### PR TITLE
example-java native-image runtime crash fix

### DIFF
--- a/docs-examples/example-java/build.gradle
+++ b/docs-examples/example-java/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(":oci-sdk")
     implementation "com.oracle.oci.sdk:oci-java-sdk-objectstorage"
     implementation "com.oracle.oci.sdk:oci-java-sdk-database"
+    compileOnly "org.graalvm.nativeimage:svm:20.1.0"
     runtimeOnly("ch.qos.logback:logback-classic")
 
     testImplementation "io.micronaut:micronaut-http-client"
@@ -18,5 +19,5 @@ dependencies {
 mainClassName = "example.Application"
 
 nativeImage {
-    args('--report-unsupported-elements-at-runtime', '--no-fallback', '--no-server')
+    args('--report-unsupported-elements-at-runtime', '--no-fallback', '--no-server', '--rerun-class-initialization-at-runtime=org.bouncycastle.jcajce.provider.drbg.DRBG$Default,org.bouncycastle.jcajce.provider.drbg.DRBG$NonceAndIV')
 }

--- a/docs-examples/example-java/src/main/java/example/BouncyCastleFeature.java
+++ b/docs-examples/example-java/src/main/java/example/BouncyCastleFeature.java
@@ -1,0 +1,19 @@
+package example;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+
+import java.security.Security;
+
+@AutomaticFeature
+public class BouncyCastleFeature implements Feature {
+
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        RuntimeClassInitialization.initializeAtBuildTime("org.bouncycastle");
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+}


### PR DESCRIPTION
This PR should fix the runtime crash that occurs when running the `example-java` native-image with a passphrase protected private key. 