### PR TITLE
Fix dependency typo

### DIFF
--- a/src/main/docs/guide/modules.adoc
+++ b/src/main/docs/guide/modules.adoc
@@ -18,7 +18,7 @@ Provides support for injecting any of the available SDK client interfaces.
 
 NOTE: This module does not have a dependency on any one module. You should add these to your project as needed. For example to use Object Storage you would define a dependency on this module as well as:
 
-dependency:com.oracle.oci.sdk:oraclecloud-java-sdk-objectstorage[version={ociVersion}]
+dependency:com.oracle.oci.sdk:oci-java-sdk-objectstorage[version={ociVersion}]
 
 === micronaut-oraclecloud-function
 


### PR DESCRIPTION
I believe `oraclecloud-java-sdk-objectstorage` should be `oci-java-sdk-objectstorage` according to https://mvnrepository.com/artifact/com.oracle.oci.sdk/oci-java-sdk-objectstorage

Not sure why the last line shows up as a diff.  Probably newline stuff, but not sure how to get rid of it.  I used the github inline editor for what it is worth