### PR TITLE
Allow oracle cloud module to function without Authentication Details

### DIFF
--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
@@ -21,6 +21,7 @@ import com.oracle.bmc.auth.internal.AuthUtils;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.annotation.*;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.context.exceptions.DisabledBeanException;
 
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -156,7 +157,7 @@ public class OracleCloudCoreFactory {
     @Context
     protected TenancyIdProvider tenantIdProvider(@Nullable BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
         if (authenticationDetailsProvider == null) {
-            throw new ConfigurationException("Invalid Oracle Cloud Configuration. If you are running locally ensure the CLI is configured by running: oci setup config");
+            throw new DisabledBeanException("Invalid Oracle Cloud Configuration. If you are running locally ensure the CLI is configured by running: oci setup config");
         }
         return () -> {
             if (authenticationDetailsProvider instanceof AuthenticationDetailsProvider) {
@@ -170,7 +171,8 @@ public class OracleCloudCoreFactory {
                     urlBasedX509CertificateSupplier = new URLBasedX509CertificateSupplier(
                             new URL(METADATA_SERVICE_URL + "identity/cert.pem"),
                             new URL(METADATA_SERVICE_URL + "identity/key.pem"),
-                            (char[]) null);
+                            (char[]) null
+                    );
                     tenantId = AuthUtils.getTenantIdFromCertificate(
                             urlBasedX509CertificateSupplier.getCertificateAndKeyPair().getCertificate()
                     );

--- a/oraclecloud-sdk-processor/src/main/java/io/micronaut/oraclecloud/clients/processor/OracleCloudSdkProcessor.java
+++ b/oraclecloud-sdk-processor/src/main/java/io/micronaut/oraclecloud/clients/processor/OracleCloudSdkProcessor.java
@@ -94,11 +94,11 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
 
             ClassName clientType = ClassName.get(packageName, simpleName);
             ClassName rxSingleType = ClassName.get("io.reactivex", "Single");
-            ClassName authProvideType = ClassName.get("io.reactivex", "Single");
+            final ClassName authProviderType = ClassName.get("com.oracle.bmc.auth", "AbstractAuthenticationDetailsProvider");
             final AnnotationSpec.Builder requiresSpec =
                     AnnotationSpec.builder(Requires.class)
                             .addMember("classes", "{$T.class, $T.class}", clientType, rxSingleType)
-                            .addMember("beans", "{$T.class}", authProvideType);
+                            .addMember("beans", "{$T.class}", authProviderType);
             builder.addAnnotation(requiresSpec.build());
             builder.addAnnotation(Singleton.class);
             builder.addModifiers(Modifier.PUBLIC);


### PR DESCRIPTION
This PR allows the Oracle Cloud module to just not load if there are no auth details 