### PR TITLE
SDK reflect config fix

### DIFF
--- a/oraclecloud-sdk/src/main/resources/META-INF/native-image/io.micronaut.oci/micronaut-oci-sdk/reflect-config.json
+++ b/oraclecloud-sdk/src/main/resources/META-INF/native-image/io.micronaut.oci/micronaut-oci-sdk/reflect-config.json
@@ -400,6 +400,10 @@
     "methods":[{"name":"<init>","parameterTypes":[] }]
   },
   {
+    "name":"org.glassfish.jersey.message.internal.EnumMessageProvider",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },  
+  {
     "name":"org.glassfish.jersey.client.ClientConfig"
   },
   {


### PR DESCRIPTION
Current SDK integration fails with ClassNotFoundException issues with `org.glassfish.jersey.message.internal.EnumMessageProvider`