### PR TITLE
ci: set githubCoreBranch to 3.5.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-oracle-cloud
 developers=Graeme Rocher
 githubBranch=master
-githubCoreBranch=3.3.x
+githubCoreBranch=3.5.x
 bomProperty=micronautOraclecloudVersion
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
 ocidocs=https://docs.oracle.com/en-us/iaas/tools/java/2.2.0/


### PR DESCRIPTION
Oracle cloud minor version 2.1.2 should have pointed to the next minor of core.