### PR TITLE
register JerseyClientBuilder for native build

### DIFF
--- a/oraclecloud-function/src/main/java/io/micronaut/oraclecloud/function/nativeimage/OciFunctionFeature.java
+++ b/oraclecloud-function/src/main/java/io/micronaut/oraclecloud/function/nativeimage/OciFunctionFeature.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fnproject.fn.api.FnConfiguration;
+import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider;
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.jni.JNIRuntimeAccess;
 import io.micronaut.core.annotation.Internal;
@@ -32,6 +33,7 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ArrayUtils;
+import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
@@ -93,6 +95,7 @@ final class OciFunctionFeature implements Feature {
                 }
             }
         }
+        registerIfNecessary(JerseyClientBuilder.class);
     }
 
     private void registerForReflection(Class<?> type) {

--- a/oraclecloud-function/src/main/java/io/micronaut/oraclecloud/function/nativeimage/OciFunctionFeature.java
+++ b/oraclecloud-function/src/main/java/io/micronaut/oraclecloud/function/nativeimage/OciFunctionFeature.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fnproject.fn.api.FnConfiguration;
-import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider;
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.jni.JNIRuntimeAccess;
 import io.micronaut.core.annotation.Internal;


### PR DESCRIPTION
Fixes: #383 

JerseyClientBuilder is registered for native compile inside `OciFunctionFeature`.