### PR TITLE
Fix #386

### DIFF
--- a/oraclecloud-sdk/src/main/java/io/micronaut/oraclecloud/clients/SdkAutomaticFeature.java
+++ b/oraclecloud-sdk/src/main/java/io/micronaut/oraclecloud/clients/SdkAutomaticFeature.java
@@ -147,8 +147,7 @@ final class SdkAutomaticFeature implements Feature {
         return Stream.of(
                 "/internal/",
                 "/auth/",
-                "/streaming/",
-                "/keymanagement/"
+                "/streaming/"
         ).anyMatch(key::contains);
     }
 


### PR DESCRIPTION
This PR adds list of classes that should use Builder that is defined in separate classes and it isn't part of the Client class.