### PR TITLE
Remove discovery dependency from OCI logging

### DIFF
--- a/oraclecloud-logging/build.gradle
+++ b/oraclecloud-logging/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     api libs.oci.loggingingestion, {
         exclude group:'commons-logging', module:'commons-logging'
     }
-    api mn.micronaut.discovery
     api mn.micronaut.inject
     api mn.micronaut.serde.jackson
     implementation projects.oraclecloudSdk

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
@@ -22,9 +22,9 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.discovery.event.ServiceReadyEvent;
 import io.micronaut.oraclecloud.core.OracleCloudCoreFactory;
 import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 
@@ -39,7 +39,7 @@ import java.util.Optional;
 @Context
 @Internal
 @Singleton
-final class OracleCloudLoggingClient implements ApplicationEventListener<ServiceReadyEvent> {
+final class OracleCloudLoggingClient implements ApplicationEventListener<ServerStartupEvent> {
 
     public static final String PREFIX = OracleCloudCoreFactory.ORACLE_CLOUD + ".logging";
 
@@ -104,7 +104,7 @@ final class OracleCloudLoggingClient implements ApplicationEventListener<Service
     }
 
     @Override
-    public void onApplicationEvent(ServiceReadyEvent event) {
+    public void onApplicationEvent(ServerStartupEvent event) {
         setLogging(internalLogging, event.getSource().getHost(), internalAppName, internalLogId);
     }
 }

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -37,11 +37,11 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         }
         def instance = Mock(EmbeddedServer.class)
         instance.getHost() >> "testHost"
-        def serviceReadyEvent = new ServerStartupEvent(instance)
+        def serverStartupEvent = new ServerStartupEvent(instance)
 
         oracleCloudLogsClient = new OracleCloudLoggingSpec.MockLogging()
 
-        new OracleCloudLoggingClient(oracleCloudLogsClient, config, Optional.empty()).onApplicationEvent(serviceReadyEvent)
+        new OracleCloudLoggingClient(oracleCloudLogsClient, config, Optional.empty()).onApplicationEvent(serverStartupEvent)
 
     }
 

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -5,9 +5,9 @@ import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.PatternLayout
 import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder
-import io.micronaut.discovery.ServiceInstance
-import io.micronaut.discovery.event.ServiceReadyEvent
 import io.micronaut.runtime.ApplicationConfiguration
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.runtime.server.event.ServerStartupEvent
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -35,9 +35,9 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         def config = Stub(ApplicationConfiguration) {
             getName() >> Optional.of("my-awesome-app")
         }
-        def instance = Mock(ServiceInstance.class)
+        def instance = Mock(EmbeddedServer.class)
         instance.getHost() >> "testHost"
-        def serviceReadyEvent = new ServiceReadyEvent(instance)
+        def serviceReadyEvent = new ServerStartupEvent(instance)
 
         oracleCloudLogsClient = new OracleCloudLoggingSpec.MockLogging()
 

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
@@ -72,11 +72,9 @@ class OracleCloudLoggingSpec extends Specification {
         logEntryBatch.stream().anyMatch(x -> x.subject == applicationConfiguration.getName().get())
 
         logEntries.stream().anyMatch(x -> x.data.contains('io.micronaut.context.env.DefaultEnvironment'))
-        logEntries.stream().anyMatch(x -> x.data.contains('io.micronaut.context.DefaultBeanContext'))
         logEntries.stream().anyMatch(x -> x.data.contains('io.micronaut.oraclecloud.logging.OracleCloudLoggingSpec'))
         logEntries.stream().anyMatch(x -> x.data.contains(logMessage))
         logEntries.stream().anyMatch(x -> x.data.contains('Established active environments'))
-        logEntries.stream().anyMatch(x -> x.data.contains('Reading bootstrap environment configuration'))
         MockAppender.getEvents().size() == 0
 
         when:

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
@@ -11,9 +11,9 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventPublisher
-import io.micronaut.discovery.ServiceInstance
-import io.micronaut.discovery.event.ServiceReadyEvent
 import io.micronaut.runtime.ApplicationConfiguration
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.runtime.server.event.ServerStartupEvent
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -30,7 +30,7 @@ class OracleCloudLoggingSpec extends Specification {
     Logging logging
 
     @Inject
-    ApplicationEventPublisher<ServiceReadyEvent> eventPublisher
+    ApplicationEventPublisher<ServerStartupEvent> eventPublisher
 
     @Inject
     ApplicationConfiguration applicationConfiguration
@@ -42,8 +42,8 @@ class OracleCloudLoggingSpec extends Specification {
         def logger = LoggerFactory.getLogger(OracleCloudLoggingSpec.class)
         PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
 
-        def instance = Mock(ServiceInstance.class)
-        def event = new ServiceReadyEvent(instance)
+        def instance = Mock(EmbeddedServer.class)
+        def event = new ServerStartupEvent(instance)
         def mockLogging = (MockLogging) logging
         1 * instance.getHost() >> testHost
         eventPublisher.publishEvent(event)


### PR DESCRIPTION
This PR removes unnecessary dependency to `microanut-descovery` module from Oracle Cloud Logging.