### PR TITLE
Fix #404 wrong property check

### DIFF
--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigCondition.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigCondition.java
@@ -22,6 +22,8 @@ import io.micronaut.core.type.Argument;
 
 import java.io.File;
 
+import static io.micronaut.oraclecloud.core.OracleCloudCoreFactory.ORACLE_CLOUD_CONFIG_PATH;
+
 /**
  * A condition used to enable file based configuration if the file exists that is specified by either {@code oci.config} or
  * available at {@code $USE_HOME/.oci/config}.
@@ -33,7 +35,7 @@ import java.io.File;
 class OracleCloudConfigCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context) {
-        String configPath = context.getProperty(OracleCloudCoreFactory.ORACLE_CLOUD + ".config", Argument.STRING)
+        String configPath = context.getProperty(ORACLE_CLOUD_CONFIG_PATH, Argument.STRING)
                 .orElseGet(() -> System.getProperty("user.home") + "/.oci/config");
         if (new File(configPath).exists()) {
             return true;

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
@@ -58,6 +58,9 @@ import java.util.Optional;
 public class OracleCloudCoreFactory {
 
     public static final String ORACLE_CLOUD = "oci";
+
+    public static final String ORACLE_CLOUD_CONFIG_PATH = ORACLE_CLOUD + ".config.path";
+
     // CHECKSTYLE:OFF
     public static final String METADATA_SERVICE_URL = "http://169.254.169.254/opc/v1/";
     // CHECKSTYLE:ON
@@ -69,7 +72,7 @@ public class OracleCloudCoreFactory {
      * @param configPath The configuration file path
      */
     protected OracleCloudCoreFactory(@Nullable @Property(name = ORACLE_CLOUD + ".config.profile") String profile,
-                                     @Nullable @Property(name = ORACLE_CLOUD + ".config.path") String configPath) {
+                                     @Nullable @Property(name = ORACLE_CLOUD_CONFIG_PATH) String configPath) {
         this.profile = profile;
         this.configPath = configPath;
     }


### PR DESCRIPTION
The `OracleCloudConfigCondition` class checked `oci.config` for string instead of `oci.config.path`. 