### PR TITLE
Fix oci sdk 3 binary compatibility

### DIFF
--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudClientConfigurationProperties.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudClientConfigurationProperties.java
@@ -18,10 +18,10 @@ package io.micronaut.oraclecloud.core;
 import com.oracle.bmc.ClientConfiguration;
 import com.oracle.bmc.circuitbreaker.CircuitBreakerConfiguration;
 import com.oracle.bmc.retrier.RetryConfiguration;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
 
 /**
  * Configuration for the {@link com.oracle.bmc.auth.AuthenticationDetailsProvider}.
@@ -33,7 +33,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 @BootstrapContextCompatible
 public class OracleCloudClientConfigurationProperties {
 
-    @ConfigurationBuilder(prefixes = "", excludes = {"retryConfiguration", "circuitBreakerConfiguration"})
+    @ConfigurationBuilder(prefixes = "", excludes = {"retryConfiguration", "circuitBreakerConfiguration", "circuitBreaker"})
     private final ClientConfiguration.ClientConfigurationBuilder clientBuilder = ClientConfiguration.builder();
 
     @ConfigurationBuilder(prefixes = "", value = "retry")

--- a/oraclecloud-httpclient-netty/build.gradle
+++ b/oraclecloud-httpclient-netty/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     testImplementation("io.micronaut:micronaut-http-server-netty")
     // for self-signed certs
     testImplementation("org.bouncycastle:bcpkix-jdk18on:1.72")
+    testImplementation(projects.oraclecloudSdk)
+    testImplementation("com.oracle.oci.sdk:oci-java-sdk-monitoring:$oci3Version")
 }
 tasks.withType(Test).configureEach {
     useJUnitPlatform()

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/httpclient/netty/NettyClientSetupSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/httpclient/netty/NettyClientSetupSpec.groovy
@@ -1,0 +1,17 @@
+package io.micronaut.oraclecloud.httpclient.netty
+
+import com.oracle.bmc.http.client.HttpProvider
+import com.oracle.bmc.monitoring.MonitoringClient
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class NettyClientSetupSpec extends Specification {
+    def test() {
+        given:
+        def ctx = ApplicationContext.run()
+
+        expect:
+        ctx.getBean(MonitoringClient)
+        HttpProvider.getDefault() instanceof NettyHttpProvider
+    }
+}


### PR DESCRIPTION
ClientConfigurationBuilder has a reference to a class (JaxRsCircuitBreaker) that is gone in oci sdk 3. This lead to a NoClassDefFoundError in the generated code that loads the config. You can't set this field from config anyway: Its type is an interface.

This PR simply excludes the relevant field from parsing. It also adds a test case to oraclecloud-httpclient-netty (which already uses oci sdk 3) to verify the binary compatibility.