### PR TITLE
Do not initialize org.glassfish.jersey.client.JerseyClientBuilder at build time

### DIFF
--- a/oraclecloud-function/src/main/java/io/micronaut/oraclecloud/function/nativeimage/OciFunctionFeature.java
+++ b/oraclecloud-function/src/main/java/io/micronaut/oraclecloud/function/nativeimage/OciFunctionFeature.java
@@ -106,12 +106,7 @@ final class OciFunctionFeature implements Feature {
                 }
             }
         }
-        Class<?> clbClass;
-        try {
-            clbClass = Class.forName("org.glassfish.jersey.client.JerseyClientBuilder");
-        } catch (ReflectiveOperationException e) {
-            clbClass = null;
-        }
+        Class<?> clbClass = access.findClassByName("org.glassfish.jersey.client.JerseyClientBuilder");
         if (clbClass != null) {
             registerIfNecessary(clbClass);
         }


### PR DESCRIPTION
Fix for issue #489 
Fix graalvm not able to compile due to initializing org.glassfish.jersey.client.JerseyClientBuilder during build time.

@yawkat 