### PR TITLE
Rework UndecidedBodyHandler

### DIFF
--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/BufferFutureHandler.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/BufferFutureHandler.java
@@ -18,14 +18,14 @@ package io.micronaut.oraclecloud.httpclient.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.LastHttpContent;
 
 import java.util.concurrent.CompletableFuture;
 
 /**
- * This channel handler accumulates input data ({@link ByteBuf} and {@link HttpContent}), and when
- * {@link LastHttpContent} is received completes a {@link #future} with the accumulated data.
+ * This channel handler accumulates input data ({@link ByteBuf} and
+ * {@link io.netty.handler.codec.http.HttpContent}), and when
+ * {@link io.netty.handler.codec.http.LastHttpContent} is received completes a {@link #future} with
+ * the accumulated data.
  */
 final class BufferFutureHandler extends DecidedBodyHandler {
     final CompletableFuture<ByteBuf> future = new CompletableFuture<>();

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/DecidedBodyHandler.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/DecidedBodyHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.httpclient.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import java.io.EOFException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Base class for handlers that replace the {@link UndecidedBodyHandler} once the user has decided how they want to
+ * consume the body. First any data buffered by {@link UndecidedBodyHandler} is processed, then a {@link HandlerImpl}
+ * is added to the pipeline to directly process the remaining chunks.
+ */
+abstract class DecidedBodyHandler {
+    private boolean done = false;
+    private volatile ChannelHandlerContext context;
+    private final List<Runnable> pendingContextActions = new ArrayList<>();
+
+    private void runWithContext(Runnable r) {
+        if (context != null) {
+            r.run();
+            return;
+        }
+        synchronized (pendingContextActions) {
+            if (context != null) {
+                r.run();
+                return;
+            }
+            pendingContextActions.add(r);
+        }
+    }
+
+    /**
+     * Trigger an upstream {@link ChannelHandlerContext#read()}.
+     */
+    final void triggerUpstreamRead() {
+        runWithContext(() -> context.read());
+    }
+
+    /**
+     * Best-effort check that this is not called in the event loop.
+     */
+    final void checkNotOnEventLoop() {
+        // embedded channel always returns true for inEventLoop
+        if (context != null && context.executor().inEventLoop() && !(context.channel() instanceof EmbeddedChannel)) {
+            throw new IllegalStateException("This method must not be called on the netty event loop");
+        }
+    }
+
+    /**
+     * Signal early cancellation by the user, remove this handler.
+     */
+    final void removeEarly() {
+        runWithContext(() -> {
+            try {
+                context.pipeline().remove(context.handler());
+            } catch (NoSuchElementException ignored) {
+            }
+        });
+    }
+
+    /**
+     * Handle an error in the pipeline.
+     *
+     * @param cause The error
+     * @return {@code true} if we were able to forward the error to the user, {@code false} if it could not be handled
+     * and should be forwarded through the pipeline.
+     */
+    abstract boolean onError(Throwable cause);
+
+    /**
+     * Handle incoming data.
+     *
+     * @param data The incoming data buffer.
+     */
+    abstract void onData(ByteBuf data);
+
+    /**
+     * Handle a {@link LastHttpContent} signalling that all data has been received successfully.
+     */
+    abstract void onComplete();
+
+    /**
+     * Handle an early cancellation (e.g. channel close).
+     */
+    final void onCancel() {
+        if (!done) {
+            onError(new EOFException());
+        }
+    }
+
+    final void onContent(HttpContent msg) {
+        onData(msg.content().retain());
+        msg.release();
+
+        if (msg instanceof LastHttpContent) {
+            done = true;
+            onComplete();
+        }
+    }
+
+    /**
+     * {@link io.netty.channel.ChannelHandler} that forwards to this {@link DecidedBodyHandler}.
+     */
+    final class HandlerImpl extends ChannelInboundHandlerAdapter {
+        @Override
+        public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+            context = ctx;
+            synchronized (pendingContextActions) {
+                for (Runnable action : pendingContextActions) {
+                    action.run();
+                }
+                pendingContextActions.clear();
+            }
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            if (!onError(cause)) {
+                ctx.fireExceptionCaught(cause);
+            }
+            ctx.pipeline().remove(this);
+            done = true;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (msg instanceof HttpContent) {
+                onContent((HttpContent) msg);
+                if (done) {
+                    ctx.pipeline().remove(this);
+                } else {
+                    ctx.read();
+                }
+            } else {
+                ctx.fireChannelRead(msg);
+            }
+        }
+
+        @Override
+        public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+            onCancel();
+        }
+    }
+}

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/DiscardingHandler.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/DiscardingHandler.java
@@ -16,34 +16,27 @@
 package io.micronaut.oraclecloud.httpclient.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.LastHttpContent;
 
 /**
  * Handler that discards incoming data.
  */
-@ChannelHandler.Sharable
-final class DiscardingHandler extends ChannelInboundHandlerAdapter {
+final class DiscardingHandler extends DecidedBodyHandler {
     static final DiscardingHandler INSTANCE = new DiscardingHandler();
 
     private DiscardingHandler() {
     }
 
     @Override
-    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (msg instanceof ByteBuf) {
-            ((ByteBuf) msg).release();
-            ctx.read();
-        } else if (msg instanceof HttpContent) {
-            ((HttpContent) msg).release();
-            if (msg instanceof LastHttpContent) {
-                ctx.pipeline().remove(this);
-            }
-        } else {
-            super.channelRead(ctx, msg);
-        }
+    boolean onError(Throwable cause) {
+        return false;
+    }
+
+    @Override
+    void onData(ByteBuf data) {
+        data.release();
+    }
+
+    @Override
+    void onComplete() {
     }
 }

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
@@ -389,7 +389,7 @@ final class NettyHttpRequest implements HttpRequest {
             ch.pipeline().addLast(sslHandler);
         }
         LimitedBufferingBodyHandler limitedBufferingBodyHandler = new LimitedBufferingBodyHandler(4096);
-        UndecidedBodyHandler undecidedBodyHandler = new UndecidedBodyHandler();
+        UndecidedBodyHandler undecidedBodyHandler = new UndecidedBodyHandler(ch.alloc());
         ch.pipeline()
                 .addLast(new HttpClientCodec())
                 .addLast(new ChannelInboundHandlerAdapter() {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/UndecidedBodyHandler.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/UndecidedBodyHandler.java
@@ -16,10 +16,10 @@
 package io.micronaut.oraclecloud.httpclient.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.concurrent.Future;
 
 import java.io.InputStream;
@@ -32,12 +32,17 @@ import java.util.concurrent.CompletableFuture;
  * that, handling is delegated to {@link StreamReadingHandler} or {@link BufferFutureHandler}.
  */
 final class UndecidedBodyHandler extends ChannelInboundHandlerAdapter {
+    private final ByteBufAllocator alloc;
     private ChannelHandlerContext context;
     private List<HttpContent> buffer;
     private Throwable failure;
 
     private boolean decided = false;
     private boolean removed = false;
+
+    UndecidedBodyHandler(ByteBufAllocator alloc) {
+        this.alloc = alloc;
+    }
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
@@ -48,15 +53,6 @@ final class UndecidedBodyHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         removed = true;
-        if (failure != null) {
-            ctx.fireExceptionCaught(failure);
-        }
-        if (buffer != null) {
-            for (HttpContent message : buffer) {
-                ctx.fireChannelRead(message);
-            }
-            buffer = null;
-        }
     }
 
     @Override
@@ -82,26 +78,11 @@ final class UndecidedBodyHandler extends ChannelInboundHandlerAdapter {
     }
 
     public void discard() {
-        if (decided) {
-            throw new IllegalStateException("Already replaced");
-        }
-        decided = true;
-
-        context.executor().execute(() -> {
-            context.pipeline()
-                    .addAfter(context.name(), null, DiscardingHandler.INSTANCE)
-                    .remove(this);
-            context.read();
-        });
+        replaceWithHandler(DiscardingHandler.INSTANCE);
     }
 
     public CompletableFuture<InputStream> asInputStream() {
-        if (decided) {
-            throw new IllegalStateException("Already replaced");
-        }
-        decided = true;
-
-        StreamReadingHandler streamReadingHandler = new StreamReadingHandler();
+        StreamReadingHandler streamReadingHandler = new StreamReadingHandler(alloc);
         if (context.executor().inEventLoop()) {
             replaceWithHandler(streamReadingHandler);
             try {
@@ -132,58 +113,47 @@ final class UndecidedBodyHandler extends ChannelInboundHandlerAdapter {
         }
     }
 
-    private void replaceWithHandler(StreamReadingHandler streamReadingHandler) {
-        if (removed) {
-            throw new IllegalStateException("UndecidedBodyHandler already removed");
-        }
-
-        context.pipeline()
-                .addAfter(context.name(), null, streamReadingHandler)
-                .addAfter(context.name(), null, new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                        if (msg instanceof HttpContent) {
-                            ctx.fireChannelRead(((HttpContent) msg).content().retain());
-                            ((HttpContent) msg).release();
-
-                            if (msg instanceof LastHttpContent) {
-                                ctx.pipeline()
-                                        .remove(this)
-                                        .remove(streamReadingHandler);
-                            }
-                        } else {
-                            ctx.fireChannelRead(msg);
-                        }
-                    }
-                })
-                .remove(this);
-        context.read();
-    }
-
-    public CompletableFuture<ByteBuf> asBuffer() {
+    private void replaceWithHandler(DecidedBodyHandler handler) {
         if (decided) {
             throw new IllegalStateException("Already replaced");
         }
         decided = true;
 
-        BufferFutureHandler futureHandler = new BufferFutureHandler();
         if (context.executor().inEventLoop()) {
-            replaceWithHandler(futureHandler);
+            replaceWithHandler0(handler);
         } else {
-            context.executor().execute(() -> replaceWithHandler(futureHandler));
+            context.executor().submit(() -> replaceWithHandler0(handler));
         }
+    }
+
+    public CompletableFuture<ByteBuf> asBuffer() {
+        BufferFutureHandler futureHandler = new BufferFutureHandler(alloc);
+        replaceWithHandler(futureHandler);
         return futureHandler.future;
     }
 
-    private void replaceWithHandler(BufferFutureHandler futureHandler) {
-        if (removed) {
-            futureHandler.future.completeExceptionally(new IllegalStateException("UndecidedBodyHandler already removed"));
+    private void replaceWithHandler0(DecidedBodyHandler handler) {
+        if (failure != null) {
+            handler.onError(failure);
+            if (buffer != null) {
+                for (HttpContent httpContent : buffer) {
+                    httpContent.release();
+                }
+            }
             return;
         }
-
-        context.pipeline()
-                .addAfter(context.name(), null, futureHandler)
-                .remove(this);
-        context.read();
+        if (buffer != null) {
+            for (HttpContent message : buffer) {
+                handler.onContent(message);
+            }
+            buffer = null;
+        }
+        if (removed) {
+            handler.onCancel();
+        } else {
+            context.pipeline()
+                    .addAfter(context.name(), null, handler.new HandlerImpl())
+                    .remove(this);
+        }
     }
 }

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/UndecidedBodyHandlerTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/UndecidedBodyHandlerTest.java
@@ -18,7 +18,7 @@ class UndecidedBodyHandlerTest {
     @Test
     public void fullyBufferedStream() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
-        UndecidedBodyHandler handler = new UndecidedBodyHandler();
+        UndecidedBodyHandler handler = new UndecidedBodyHandler(channel.alloc());
         channel.pipeline().addLast(handler);
 
         channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8))));
@@ -33,7 +33,7 @@ class UndecidedBodyHandlerTest {
     @Test
     public void fullyBufferedFuture() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
-        UndecidedBodyHandler handler = new UndecidedBodyHandler();
+        UndecidedBodyHandler handler = new UndecidedBodyHandler(channel.alloc());
         channel.pipeline().addLast(handler);
 
         channel.writeInbound(new DefaultLastHttpContent(Unpooled.wrappedBuffer("foo".getBytes(StandardCharsets.UTF_8))));
@@ -47,7 +47,7 @@ class UndecidedBodyHandlerTest {
     @Test
     public void closeImmediatelyAsBuffer() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
-        UndecidedBodyHandler handler = new UndecidedBodyHandler();
+        UndecidedBodyHandler handler = new UndecidedBodyHandler(channel.alloc());
         channel.pipeline().addLast(handler);
         channel.writeInbound(new DefaultLastHttpContent());
 
@@ -64,7 +64,7 @@ class UndecidedBodyHandlerTest {
     @Test
     public void closeImmediatelyAsStream() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
-        UndecidedBodyHandler handler = new UndecidedBodyHandler();
+        UndecidedBodyHandler handler = new UndecidedBodyHandler(channel.alloc());
         channel.pipeline().addLast(handler);
         channel.writeInbound(new DefaultLastHttpContent());
 


### PR DESCRIPTION
If you call asBuffer and then immediately close the connection, it was possible that the buffered data was lost and the downstream handlers never finish.

This patch performs the forwarding to the "decided" handler independently from the pipeline, and properly handles the case where the channel is shut down at the time of forwarding.