### PR TITLE
2.3.x branch: Update the OCI SDK 3 version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 projectVersion=2.3.5-SNAPSHOT
 projectGroup=io.micronaut.oraclecloud
 micronautDocsVersion=2.0.0
-micronautVersion=3.7.2
+micronautVersion=3.9.1
 micronautTestVersion=3.5.0
 groovyVersion=3.0.10
 spockVersion=2.1-groovy-3.0
 
 fnVersion=1.0.150
 ociVersion=2.41.0
-oci3Version=3.0.1
+oci3Version=3.14.0
 ojdbcVersion=21.6.0.0.1
 
 title=Micronaut Oracle Cloud

--- a/oraclecloud-httpclient-netty/build.gradle
+++ b/oraclecloud-httpclient-netty/build.gradle
@@ -5,6 +5,9 @@ plugins {
 dependencies {
     implementation("io.netty:netty-codec-http")
     api("com.oracle.oci.sdk:oci-java-sdk-common-httpclient:$oci3Version")
+    implementation("com.fasterxml.jackson.core:jackson-core")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+
     testImplementation("io.micronaut:micronaut-http-server-netty")
     // for self-signed certs
     testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClientBuilder.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClientBuilder.java
@@ -54,6 +54,13 @@ final class NettyHttpClientBuilder implements HttpClientBuilder {
     }
 
     @Override
+    public HttpClientBuilder baseUri(String uri) {
+        Objects.requireNonNull(uri, "baseUri");
+        this.baseUri = URI.create(uri);
+        return this;
+    }
+
+    @Override
     public <T> HttpClientBuilder property(ClientProperty<T> key, T value) {
         if (key == StandardClientProperties.CONNECT_TIMEOUT) {
             connectTimeout = (Duration) value;

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpProvider.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpProvider.java
@@ -17,6 +17,8 @@ package io.micronaut.oraclecloud.httpclient.netty;
 
 import com.oracle.bmc.http.client.HttpClientBuilder;
 import com.oracle.bmc.http.client.HttpProvider;
+import com.oracle.bmc.http.client.Serializer;
+import io.micronaut.oraclecloud.serialization.jackson.JacksonSerializer;
 
 /**
  * Netty-based implementation of {@link HttpProvider}.
@@ -28,6 +30,11 @@ public final class NettyHttpProvider implements HttpProvider {
     @Override
     public HttpClientBuilder newBuilder() {
         return new NettyHttpClientBuilder();
+    }
+
+    @Override
+    public Serializer getSerializer() {
+        return JacksonSerializer.getDefaultSerializer();
     }
 }
 

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
@@ -19,7 +19,7 @@ import com.oracle.bmc.http.client.HttpRequest;
 import com.oracle.bmc.http.client.HttpResponse;
 import com.oracle.bmc.http.client.Method;
 import com.oracle.bmc.http.client.RequestInterceptor;
-import com.oracle.bmc.http.client.Serialization;
+import io.micronaut.oraclecloud.serialization.jackson.JacksonSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -126,7 +126,7 @@ final class NettyHttpRequest implements HttpRequest {
             //  anything but String
             String json;
             try {
-                json = Serialization.getObjectMapper().writeValueAsString(body);
+                json = JacksonSerializer.getDefaultObjectMapper().writeValueAsString(body);
             } catch (IOException e) {
                 throw new IllegalArgumentException("Unable to process JSON body", e);
             }

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpResponse.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpResponse.java
@@ -17,7 +17,7 @@ package io.micronaut.oraclecloud.httpclient.netty;
 
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.oracle.bmc.http.client.HttpResponse;
-import com.oracle.bmc.http.client.Serialization;
+import io.micronaut.oraclecloud.serialization.jackson.JacksonSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 
@@ -78,7 +78,7 @@ final class NettyHttpResponse implements HttpResponse {
     public <T> CompletionStage<T> body(Class<T> type) {
         return thenApply(bodyAsBuffer(), buf -> {
             try {
-                return Serialization.getObjectMapper().readValue((InputStream) new ByteBufInputStream(buf), type);
+                return JacksonSerializer.getDefaultObjectMapper().readValue((InputStream) new ByteBufInputStream(buf), type);
             } catch (IOException e) {
                 throw new CompletionException(e);
             } finally {
@@ -89,10 +89,10 @@ final class NettyHttpResponse implements HttpResponse {
 
     @Override
     public <T> CompletionStage<List<T>> listBody(Class<T> type) {
-        CollectionType listType = Serialization.getObjectMapper().getTypeFactory().constructCollectionType(List.class, type);
+        CollectionType listType = JacksonSerializer.getDefaultObjectMapper().getTypeFactory().constructCollectionType(List.class, type);
         return thenApply(bodyAsBuffer(), buf -> {
             try {
-                return Serialization.getObjectMapper().readValue((InputStream) new ByteBufInputStream(buf), listType);
+                return JacksonSerializer.getDefaultObjectMapper().readValue((InputStream) new ByteBufInputStream(buf), listType);
             } catch (IOException e) {
                 throw new CompletionException(e);
             } finally {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/JacksonSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/JacksonSerializer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serialization.jackson;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.oracle.bmc.http.client.InternalSdk;
+import com.oracle.bmc.http.client.Serializer;
+import io.micronaut.oraclecloud.serialization.jackson.internal.ExplicitlySetFilter;
+import io.micronaut.oraclecloud.serialization.jackson.internal.Rfc3339DateFormat;
+
+import java.io.IOException;
+
+import static com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel.EXPLICITLY_SET_FILTER_NAME;
+
+/**
+ * Implementation of Serializer for Jackson.
+ *
+ * <p>Use the {@link JacksonSerializer#getDefaultSerializer()} to get the instance with default
+ * configuration for java sdk.
+ *
+ * <p>Exposed only for internal use.
+ */
+@InternalSdk
+public final class JacksonSerializer implements Serializer {
+
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
+    private static final JacksonSerializer DEFAULT_SERIALIZER =
+            new JacksonSerializer(DEFAULT_OBJECT_MAPPER);
+
+    static {
+        // Our default object mapper will ignore unknown properties when
+        // deserializing results
+        DEFAULT_OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // Serialize Date instances using the DateFormat we specify, do not serialize into
+        // timestamps.
+        DEFAULT_OBJECT_MAPPER.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        // set explicit formatter that will serialize correctly
+        DEFAULT_OBJECT_MAPPER.setDateFormat(new Rfc3339DateFormat());
+
+        FilterProvider filters =
+                new SimpleFilterProvider()
+                        .addFilter(EXPLICITLY_SET_FILTER_NAME, ExplicitlySetFilter.INSTANCE);
+
+        DEFAULT_OBJECT_MAPPER.setFilterProvider(filters);
+    }
+
+    private final ObjectMapper objectMapper;
+
+    @InternalSdk
+    JacksonSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public <T> T readValue(String s, Class<T> type) throws IOException {
+        return objectMapper.readValue(s, type);
+    }
+
+    @Override
+    public <T> T readValue(byte[] bytes, Class<T> type) throws IOException {
+        return objectMapper.readValue(bytes, type);
+    }
+
+    @Override
+    public String writeValueAsString(Object o) throws IOException {
+        return objectMapper.writeValueAsString(o);
+    }
+
+    /**
+     * Get the instance of Jackson JSON mapper with default configuration for java sdk
+     * serialization.
+     *
+     * @return JSON mapper to handle JSON serialization.
+     */
+    @InternalSdk
+    public static JacksonSerializer getDefaultSerializer() {
+        return DEFAULT_SERIALIZER;
+    }
+
+    /**
+     * Get the instance of Object Mapper with default configuration for java sdk serialization.
+     *
+     * @return Object mapper to handle JSON serialization
+     */
+    @InternalSdk
+    public static ObjectMapper getDefaultObjectMapper() {
+        return DEFAULT_OBJECT_MAPPER;
+    }
+}

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/ExplicitlySetFilter.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/ExplicitlySetFilter.java
@@ -56,11 +56,12 @@ public final class ExplicitlySetFilter extends SimpleBeanPropertyFilter {
                 if (fieldValue != null) {
                     // not null, definitely serialize
                     writer.serializeAsField(pojo, jgen, provider);
-                } else if (pojo instanceof ExplicitlySetBmcModel) {
+                } else if (
+                        pojo instanceof ExplicitlySetBmcModel &&
+                        ((ExplicitlySetBmcModel) pojo).wasPropertyExplicitlySet(writer.getName())
+                ) {
                     // null, find out if null was explicitly set using the method from BmcModel common class
-                    if (((ExplicitlySetBmcModel) pojo).wasPropertyExplicitlySet(writer.getName())) {
-                        writer.serializeAsField(pojo, jgen, provider);
-                    }
+                    writer.serializeAsField(pojo, jgen, provider);
                 }
             } finally {
                 field.setAccessible(accessible);

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/ExplicitlySetFilter.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/ExplicitlySetFilter.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serialization.jackson.internal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.oracle.bmc.http.client.InternalSdk;
+import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel;
+import java.lang.reflect.Field;
+
+import static com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel.EXPLICITLY_SET_PROPERTY_NAME;
+
+/**
+ * Jackson implementation of the explicitly set filter.
+ * The filter will include in the serialization all properties that were explicitly set by user and will exclude all
+ * others based on methods provided by the {@link ExplicitlySetBmcModel}.
+ */
+@InternalSdk
+public final class ExplicitlySetFilter extends SimpleBeanPropertyFilter {
+    public static final ExplicitlySetFilter INSTANCE = new ExplicitlySetFilter();
+    private static final org.slf4j.Logger LOG =
+            org.slf4j.LoggerFactory.getLogger(ExplicitlySetFilter.class);
+
+    private ExplicitlySetFilter() {
+
+    }
+
+    @Override
+    public void serializeAsField(
+            Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer)
+            throws Exception {
+
+        if (include(writer)) {
+            Field field = getMatchingDeclaredField(pojo.getClass(), writer.getName());
+            boolean accessible = field.isAccessible();
+            try {
+                field.setAccessible(true);
+                Object fieldValue = field.get(pojo);
+                if (fieldValue != null) {
+                    // not null, definitely serialize
+                    writer.serializeAsField(pojo, jgen, provider);
+                } else if (pojo instanceof ExplicitlySetBmcModel) {
+                    // null, find out if null was explicitly set using the method from BmcModel common class
+                    if (((ExplicitlySetBmcModel) pojo).wasPropertyExplicitlySet(writer.getName())) {
+                        writer.serializeAsField(pojo, jgen, provider);
+                    }
+                }
+            } finally {
+                field.setAccessible(accessible);
+            }
+        } else if (!jgen.canOmitFields()) {
+            // since 2.3
+            writer.serializeAsOmittedField(pojo, jgen, provider);
+        }
+    }
+
+    private static Field getMatchingDeclaredField(Class<?> pojoClass, String fieldName)
+            throws NoSuchFieldException {
+        // Try matching the exact field name
+        try {
+            return getDeclaredField(pojoClass, fieldName);
+        } catch (NoSuchFieldException nsfe) {
+            LOG.debug("Exact field name match failed for {}", fieldName);
+        }
+        // If not found, try converting the field name from snake case to camel case
+        String lowerCamelCased = lowerUnderscoreToLowerCamel(fieldName);
+        try {
+            return getDeclaredField(pojoClass, lowerCamelCased);
+        } catch (NoSuchFieldException nsfe) {
+            LOG.debug(
+                    "Exact field name match failed for %s, lower camel-case %s didn't work either",
+                    fieldName, lowerCamelCased);
+            // Look through all fields and find a field with a matching JsonProperty annotation
+            for (Field f : pojoClass.getDeclaredFields()) {
+                for (JsonProperty a : f.getAnnotationsByType(JsonProperty.class)) {
+                    if (fieldName.equals(a.value())) {
+                        return f;
+                    }
+                }
+            }
+            throw nsfe;
+        }
+    }
+
+    private static Field getDeclaredField(Class<?> pojoClass, String fieldName)
+            throws NoSuchFieldException {
+        try {
+            return pojoClass.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException nsfe) {
+            Class<?> superclass = pojoClass.getSuperclass();
+            if (superclass != null) {
+                return getDeclaredField(superclass, fieldName);
+            } else {
+                throw nsfe;
+            }
+        }
+    }
+
+    @Override
+    protected boolean include(BeanPropertyWriter writer) {
+        return include((PropertyWriter) writer);
+    }
+
+    @Override
+    protected boolean include(PropertyWriter writer) {
+        return !EXPLICITLY_SET_PROPERTY_NAME.equals(writer.getName());
+    }
+
+    private static String lowerUnderscoreToLowerCamel(String s) {
+        StringBuilder sb = new StringBuilder(s);
+
+        for (int i = 0; i < sb.length(); i++) {
+            if (sb.charAt(i) == '_') {
+                sb.deleteCharAt(i);
+                sb.replace(i, i + 1, String.valueOf(Character.toUpperCase(sb.charAt(i))));
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/Rfc3339DateFormat.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/Rfc3339DateFormat.java
@@ -32,10 +32,6 @@ import java.util.Date;
 @SuppressWarnings({"deprecation"})
 public class Rfc3339DateFormat extends StdDateFormat {
 
-    public Rfc3339DateFormat() {
-
-    }
-
     @Override
     public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition fieldPosition) {
         // Same as ISO8601DateFormat but we always serialize millis

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/Rfc3339DateFormat.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serialization/jackson/internal/Rfc3339DateFormat.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serialization.jackson.internal;
+
+import com.fasterxml.jackson.databind.util.ISO8601Utils;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.oracle.bmc.http.client.InternalSdk;
+
+import java.text.FieldPosition;
+import java.util.Date;
+
+/**
+ * Swagger uses RFC3339 formats for date. By default, Jackson's StdDateFormatter will use a format
+ * that is not exactly compatible (ex, uses hour offsets instead of 'Z').
+ *
+ * <p>Leave deserialization alone, only take over serialization.
+ */
+@InternalSdk
+@SuppressWarnings({"deprecation"})
+public class Rfc3339DateFormat extends StdDateFormat {
+
+    public Rfc3339DateFormat() {
+
+    }
+
+    @Override
+    public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition fieldPosition) {
+        // Same as ISO8601DateFormat but we always serialize millis
+        toAppendTo.append(ISO8601Utils.format(date, true));
+        return toAppendTo;
+    }
+
+    @Override
+    public Rfc3339DateFormat clone() {
+        return new Rfc3339DateFormat();
+    }
+
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/DateSerdeSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/DateSerdeSpec.groovy
@@ -1,0 +1,82 @@
+package io.micronaut.oraclecloud.serialization.jackson
+
+import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel
+import io.micronaut.runtime.server.EmbeddedServer
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.Month
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class DateSerdeSpec extends SerdeSpecBase {
+
+    void "test Date serialization"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        when:
+        def dateTime = ZonedDateTime.of(
+                LocalDateTime.of(2000, Month.JANUARY, 2, 3, 4, 5, (int) 678e6),
+                ZoneId.of("America/Toronto")
+        )
+        def date = new Date(dateTime.toInstant().toEpochMilli())
+
+        var value = echoTest(embeddedServer, date).replaceAll('"', '')
+        var requiredValue = "2000-01-02T08:04:05.678Z"
+
+        then:
+        requiredValue == value
+    }
+
+    void "test Date deserialization '#dateString'"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        Calendar calendar = Calendar.getInstance(
+                TimeZone.getTimeZone(ZoneId.of('-05:00')),
+                Locale.CANADA
+        )
+        calendar.setTimeInMillis(789)
+        calendar.set(2000, Calendar.JANUARY, 2, 3, 4, 56)
+        Date requiredDate = calendar.getTime()
+
+        when:
+        var dateModel = echoTest(embeddedServer, dateString, DateModel)
+
+        then:
+        requiredDate == dateModel.date
+
+        where:
+        dateString                                       | _
+        '{"date":"2000-01-02T03:04:56.789-05:00"}'       | _
+        '{"date":"2000-01-02T08:04:56.789Z"}'            | _
+        '{"date":"2000-01-02T09:04:56.789+01:00"}'       | _
+    }
+
+    void "test Date deserialization '#dateText'"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        when:
+        var body = "{\"date\":\"${dateText}\"}"
+        var dateModel = echoTest(embeddedServer, body.toString(), DateModel)
+        var date = Date.from(Instant.parse(dateText))
+
+        then:
+        date == dateModel.date
+
+        where:
+        dateText | _
+        '1937-01-01T12:00:27.873834939Z'      | _
+        '2021-04-29T10:00:00Z'                | _
+        // Does not work for Java 8 and Java 11
+        // '1937-01-01T12:00:27.873834939+00:20' | _
+        // '2021-05-13T10:58:09.628313-07:00'    | _
+    }
+
+    static class DateModel extends ExplicitlySetBmcModel {
+        Date date
+    }
+
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/EnumSerdeSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/EnumSerdeSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.oraclecloud.serialization.jackson
+
+
+import io.micronaut.oraclecloud.serialization.jackson.model.TestStateEnum
+import io.micronaut.runtime.server.EmbeddedServer
+
+class EnumSerdeSpec extends SerdeSpecBase {
+
+    void "test enum serialization"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        expect:
+        echoTest(embeddedServer, TestStateEnum.Active) == '"active"'
+        echoTest(embeddedServer, TestStateEnum.Inactive) == '"inactive"'
+        echoTest(embeddedServer, TestStateEnum.Deleted) == '"deleted"'
+        echoTest(embeddedServer, TestStateEnum.UnknownEnumValue) == 'null'
+    }
+
+    void "test enum deserializatioin"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        expect:
+        echoTest(embeddedServer, '"active"', TestStateEnum) == TestStateEnum.Active
+        echoTest(embeddedServer, '"inactive"', TestStateEnum) == TestStateEnum.Inactive
+        echoTest(embeddedServer, '"deleted"', TestStateEnum) == TestStateEnum.Deleted
+        echoTest(embeddedServer, '"unknown value"', TestStateEnum) == TestStateEnum.UnknownEnumValue
+        // Seems to be a wrong result
+        echoTest(embeddedServer, 'null', TestStateEnum) == null
+    }
+
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/ExplicitlySetSerdeSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/ExplicitlySetSerdeSpec.groovy
@@ -1,0 +1,130 @@
+package io.micronaut.oraclecloud.serialization.jackson
+
+import com.fasterxml.jackson.annotation.JsonFilter
+import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel
+import io.micronaut.oraclecloud.serialization.jackson.model.BaseModel
+import io.micronaut.oraclecloud.serialization.jackson.model.ComplexModel
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Unroll
+
+class ExplicitlySetSerdeSpec extends SerdeSpecBase {
+
+    void "OCI SDK Model serialization test"() throws Exception {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+        MyModel myModel = new MyModel("value")
+
+        when:
+        var body = echoTest(embeddedServer, myModel)
+
+        then:
+        '{"string":"value"}' == body
+    }
+
+    void "Explicitly set OCI SDK Model serialization test"() throws Exception {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        when:
+        var body = echoTest(embeddedServer, new MyModel(null))
+
+        then:
+        '{"string":null}' == body
+
+        when:
+        body = echoTest(embeddedServer, new MyModel())
+
+        then:
+        '{}' == body
+    }
+
+    void "Test extra properties deserialization does not throw exception"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        when:
+        var value = '{"string":"value","extraString":"extraValue"}'
+        var myModel = echoTest(embeddedServer, value, MyModel)
+
+        then:
+        notThrown(Exception)
+        myModel.string == "value"
+    }
+
+    @Unroll
+    void "Complex model serialization test #modelBuilder"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        when:
+        var response = echoTest(embeddedServer, modelBuilder.build())
+
+        then:
+        response == json
+
+        where:
+        modelBuilder                                                                                    | json
+        ComplexModel.builder() | '{"type":"complex"}'
+        ComplexModel.builder().string("one")                                                            | '{"type":"complex","string":"one"}'
+        ComplexModel.builder().string(null)                                                             | '{"type":"complex","string":null}'
+        ComplexModel.builder().baseString("one").string("two").integer(null)                            | '{"type":"complex","baseString":"one","string":"two","int":null}'
+        ComplexModel.builder().baseInteger(null).integer(null).list(null)                               | '{"type":"complex","baseInt":null,"int":null,"list":null}'
+        ComplexModel.builder().string("one").baseInteger(1).integer(null).baseString(null).list(["1"])  | '{"type":"complex","baseString":null,"baseInt":1,"string":"one","int":null,"list":["1"]}'
+        ComplexModel.builder().baseString(null).baseInteger(null).string(null).integer(null).list(null) | '{"type":"complex","baseString":null,"baseInt":null,"string":null,"int":null,"list":null}'
+    }
+
+    @Unroll
+    void "Simple model deserialization for #modelBuilder"() {
+        EmbeddedServer embeddedServer = initContext()
+
+        when:
+        var response = echoTest(embeddedServer, json, BaseModel)
+
+        then:
+        modelBuilder.build().equals(response, false)
+
+        where:
+        modelBuilder                                            | json
+        BaseModel.builder()                                     | '{}'
+        BaseModel.builder().baseString("one").baseInteger(1)    | '{"baseString":"one","baseInt":1}'
+        BaseModel.builder().baseString("one")                   | '{"baseString":"one"}'
+        BaseModel.builder().baseInteger(null)                   | '{"baseInt":null}'
+        BaseModel.builder().baseString("two").baseInteger(null) | '{"baseString":"two","baseInt":null}'
+        BaseModel.builder().baseInteger(null).baseString(null)  | '{"baseString":null,"baseInt":null}'
+        BaseModel.builder()                                     | '{"type":"unknown"}'
+    }
+
+    @Unroll
+    void "Complex model deserialization for #modelBuilder"() {
+        EmbeddedServer embeddedServer = initContext()
+
+        when:
+        var response = echoTest(embeddedServer, json, BaseModel)
+
+        then:
+        modelBuilder.build().equals(response, false)
+
+        where:
+        modelBuilder                                                                                    | json
+        ComplexModel.builder()                                                                          | '{"type":"complex"}'
+        ComplexModel.builder().string("one")                                                            | '{"type":"complex","string":"one"}'
+        ComplexModel.builder().string(null)                                                             | '{"type":"complex","string":null}'
+        ComplexModel.builder().baseString("one").string("two").integer(null)                            | '{"type":"complex","string":"two","int":null,"baseString":"one"}'
+        ComplexModel.builder().baseInteger(null).integer(null).list(null)                               | '{"type":"complex","int":null,"list":null,"baseInt":null}'
+        ComplexModel.builder().string("one").baseInteger(1).integer(null).baseString(null).list(["1"])  | '{"type":"complex","string":"one","int":null,"list":["1"],"baseString":null,"baseInt":1}'
+        ComplexModel.builder().baseString(null).baseInteger(null).string(null).integer(null).list(null) | '{"type":"complex","string":null,"int":null,"list":null,"baseString":null,"baseInt":null}'
+    }
+
+    @JsonFilter("explicitlySetFilter")
+    static class MyModel extends ExplicitlySetBmcModel {
+        String string
+
+        MyModel() {}
+
+        MyModel(String string) {
+            this.string = string
+            this.markPropertyAsExplicitlySet("string")
+        }
+    }
+
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/SerdeSpecBase.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/SerdeSpecBase.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.oraclecloud.serialization.jackson
+
+import com.oracle.bmc.http.client.HttpClient
+import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.oraclecloud.httpclient.netty.NettyHttpClientBuilder
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+import static com.oracle.bmc.http.client.Method.POST
+
+class SerdeSpecBase extends Specification {
+
+    EmbeddedServer initContext() {
+        ApplicationContext ctx = ApplicationContext.run([
+                'micronaut.server.port': '-1'
+        ])
+        return ctx.getBean(EmbeddedServer.class).start()
+    }
+
+    static <T> T echoTest(EmbeddedServer embeddedServer, Object requestBody, Class<T> bodyType = String) throws Exception {
+        try (HttpClient client = new NettyHttpClientBuilder()
+                .baseUri(embeddedServer.URI)
+                .build()) {
+            var response = client.createRequest(POST)
+                    .appendPathPart('/echo')
+                    .body(requestBody)
+                    .execute().toCompletableFuture().get()
+            if (bodyType == String) {
+                return response.textBody().toCompletableFuture().get()
+            }
+            return response.body(bodyType).toCompletableFuture().get()
+        }
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/BaseModel.java
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/BaseModel.java
@@ -1,0 +1,98 @@
+package io.micronaut.oraclecloud.serialization.jackson.model;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = BaseModel.class)
+@JsonSubTypes(
+    @JsonSubTypes.Type(value = ComplexModel.class, name = "complex")
+)
+@JsonFilter("explicitlySetFilter")
+@JsonDeserialize(builder = BaseModel.Builder.class)
+public class BaseModel extends ExplicitlySetBmcModel {
+    @JsonProperty("baseString")
+    protected String baseString;
+
+    @JsonProperty("baseInt")
+    protected Integer baseInteger;
+
+    public BaseModel(String baseString, Integer baseInteger) {
+        this.baseString = baseString;
+        this.baseInteger = baseInteger;
+    }
+
+    public String getBaseString() {
+        return baseString;
+    }
+
+    public Integer getBaseInteger() {
+        return baseInteger;
+    }
+
+    public boolean equals(Object o) {
+        return equals(o, true);
+    }
+
+    public boolean equals(Object o, boolean explicitlySet) {
+        if (!(o instanceof BaseModel)) {
+            return false;
+        }
+        BaseModel other = (BaseModel) o;
+        return Objects.equals(other.baseString, baseString) &&
+            Objects.equals(other.baseInteger, baseInteger) &&
+            (!explicitlySet || super.equals(o));
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String toString() {
+        return "{" +
+            "baseString=" + (baseString != null || wasPropertyExplicitlySet("baseString") ? baseString : "") + "," +
+            "baseInteger=" + (baseInteger != null || wasPropertyExplicitlySet("baseInt") ? baseInteger : "") +
+        "}";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    protected static class Builder {
+        @JsonProperty("baseString")
+        protected String baseString;
+
+        @JsonProperty("baseInt")
+        protected Integer baseInteger;
+
+        protected final Set<String> explicitlySet = new HashSet<>();
+
+        public Builder baseString(String baseString) {
+            this.baseString = baseString;
+            explicitlySet.add("baseString");
+            return this;
+        }
+
+        public Builder baseInteger(Integer baseInteger) {
+            this.baseInteger = baseInteger;
+            explicitlySet.add("baseInt");
+            return this;
+        }
+
+        public BaseModel build() {
+            BaseModel model = new BaseModel(baseString, baseInteger);
+            explicitlySet.forEach(model::markPropertyAsExplicitlySet);
+            return model;
+        }
+
+        public String toString() {
+            return build().toString();
+        }
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/BaseModel.java
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/BaseModel.java
@@ -87,7 +87,9 @@ public class BaseModel extends ExplicitlySetBmcModel {
 
         public BaseModel build() {
             BaseModel model = new BaseModel(baseString, baseInteger);
-            explicitlySet.forEach(model::markPropertyAsExplicitlySet);
+            for (String property: explicitlySet) {
+                model.markPropertyAsExplicitlySet(property);
+            }
             return model;
         }
 

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/ComplexModel.java
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/ComplexModel.java
@@ -1,0 +1,117 @@
+package io.micronaut.oraclecloud.serialization.jackson.model;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.List;
+import java.util.Objects;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonFilter("explicitlySetFilter")
+@JsonDeserialize(builder = ComplexModel.Builder.class)
+public class ComplexModel extends BaseModel {
+
+    @JsonProperty("baseString")
+    private String baseString;
+
+    @JsonProperty("baseInt")
+    private Integer baseInteger;
+
+    @JsonProperty("string")
+    private String string;
+
+    @JsonProperty("int")
+    private Integer integer;
+
+    @JsonProperty("list")
+    private List<String> list;
+
+    public String getString() {
+        return string;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+
+    public List<String> getList() {
+        return list;
+    }
+
+    public ComplexModel(String baseString, Integer baseInteger, String string, Integer integer, List<String> list) {
+        super(baseString, baseInteger);
+        this.string = string;
+        this.integer = integer;
+        this.list = list;
+    }
+
+    public boolean equals(Object o, boolean explicitlySet) {
+        if (!(o instanceof ComplexModel)) {
+            return false;
+        }
+        ComplexModel other = (ComplexModel) o;
+        return Objects.equals(other.string, string) &&
+            Objects.equals(other.integer, integer) &&
+            Objects.equals(other.list, list) &&
+            super.equals(other, explicitlySet);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String toString() {
+        return "{" +
+            "baseString=" + (getBaseString() != null || wasPropertyExplicitlySet("baseString") ? getBaseString() : "") + "," +
+            "baseInt=" + (getBaseInteger() != null || wasPropertyExplicitlySet("baseInt") ? getBaseInteger() : "") + "," +
+            "string=" + (string != null || wasPropertyExplicitlySet("string") ? string : "") + "," +
+            "int=" + (integer != null || wasPropertyExplicitlySet("int") ? integer : "") + "," +
+            "list=" + (list != null || wasPropertyExplicitlySet("list") ? list : "") +
+        "}";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    protected static class Builder extends BaseModel.Builder {
+        @JsonProperty("string")
+        private String string;
+
+        @JsonProperty("int")
+        private Integer integer;
+
+        @JsonProperty("list")
+        private List<String> list;
+
+        public Builder string(String string) {
+            this.string = string;
+            explicitlySet.add("string");
+            return this;
+        }
+
+        public Builder integer(Integer integer) {
+            this.integer = integer;
+            explicitlySet.add("int");
+            return this;
+        }
+
+        public Builder list(List<String> list) {
+            this.list = list;
+            explicitlySet.add("list");
+            return this;
+        }
+
+        public ComplexModel build() {
+            ComplexModel model = new ComplexModel(baseString, baseInteger, string, integer, list);
+            for (String property: explicitlySet) {
+                model.markPropertyAsExplicitlySet(property);
+            }
+            return model;
+        }
+
+        public String toString() {
+            return build().toString();
+        }
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/TestStateEnum.java
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serialization/jackson/model/TestStateEnum.java
@@ -1,0 +1,37 @@
+package io.micronaut.oraclecloud.serialization.jackson.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.oracle.bmc.http.internal.BmcEnum;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum TestStateEnum implements BmcEnum {
+    Active("active"),
+    Inactive("inactive"),
+    Deleted("deleted"),
+    UnknownEnumValue(null);
+
+    private String value;
+
+    private static final Map<String, TestStateEnum> valueMap = Arrays.stream(values())
+        .collect(Collectors.toMap(v -> v.getValue(), Function.identity()));
+
+    TestStateEnum(String value) {
+        this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static TestStateEnum create(String value) {
+        return valueMap.getOrDefault(value, UnknownEnumValue);
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyRule.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyRule.java
@@ -101,6 +101,16 @@ public class NettyRule implements BeforeEachCallback, AfterEachCallback {
                                     }
                                     return null;
                                 }
+
+                                @Override
+                                public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                                    if (handleContinue) {
+                                        // don't throw an error when we shut down before the request is done
+                                        ctx.fireChannelInactive();
+                                    } else {
+                                        super.channelInactive(ctx);
+                                    }
+                                }
                             });
                         }
                         ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyTest.java
@@ -5,9 +5,9 @@ import com.oracle.bmc.http.client.HttpClient;
 import com.oracle.bmc.http.client.HttpProvider;
 import com.oracle.bmc.http.client.HttpResponse;
 import com.oracle.bmc.http.client.Method;
-import com.oracle.bmc.http.client.Serialization;
 import com.oracle.bmc.http.client.StandardClientProperties;
 import com.oracle.bmc.http.client.io.DuplicatableInputStream;
+import io.micronaut.oraclecloud.serialization.jackson.JacksonSerializer;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -27,7 +27,7 @@ import java.nio.charset.StandardCharsets;
 
 @ExtendWith(NettyRule.class)
 public class NettyTest {
-    private static final ObjectMapper MAPPER = Serialization.getObjectMapper();
+    private static final ObjectMapper MAPPER = JacksonSerializer.getDefaultObjectMapper();
     private static final HttpProvider PROVIDER = new NettyHttpProvider();
 
     public NettyRule netty;

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.4.5'
+    id 'io.micronaut.build.shared.settings' version '5.4.9'
 }
 
 gradle.ext.ociBom = new groovy.xml.XmlSlurper().parse(


### PR DESCRIPTION
The PR updates the OCI SDK version and adds a Jackson implementation for the serializer that now is not supplied by default.