### PR TITLE
Retreive vault values as byte arrays

### DIFF
--- a/oraclecloud-vault/src/main/java/io/micronaut/oraclecloud/discovery/vault/OracleCloudVaultConfigurationClient.java
+++ b/oraclecloud-vault/src/main/java/io/micronaut/oraclecloud/discovery/vault/OracleCloudVaultConfigurationClient.java
@@ -126,7 +126,7 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
             for (ListSecretsResponse response : responses) {
                 retrieved += response.getItems().size();
                 response.getItems().forEach(summary -> {
-                    String secretValue = getSecretValue(summary.getId());
+                    byte[] secretValue = getSecretValue(summary.getId());
                     secrets.put(
                             summary.getSecretName(),
                             secretValue
@@ -164,7 +164,7 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
         return request.build();
     }
 
-    private String getSecretValue(String secretOcid) {
+    private byte[] getSecretValue(String secretOcid) {
         GetSecretBundleRequest getSecretBundleRequest = GetSecretBundleRequest
                 .builder()
                 .secretId(secretOcid)
@@ -178,8 +178,7 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
                 (Base64SecretBundleContentDetails) getSecretBundleResponse.
                         getSecretBundle().getSecretBundleContent();
 
-        byte[] secretValueDecoded = Base64.getDecoder().decode(base64SecretBundleContentDetails.getContent());
-        return new String(secretValueDecoded);
+        return Base64.getDecoder().decode(base64SecretBundleContentDetails.getContent());
     }
 
     @Override

--- a/oraclecloud-vault/src/test/groovy/io/micronaut/oraclecloud/discovery/vault/OracleCloudVaultConfigurationClientSpec.groovy
+++ b/oraclecloud-vault/src/test/groovy/io/micronaut/oraclecloud/discovery/vault/OracleCloudVaultConfigurationClientSpec.groovy
@@ -41,7 +41,8 @@ class OracleCloudVaultConfigurationClientSpec extends Specification {
 
         then:
         !propertySource.isEmpty()
-        propertySource.get(secretName) == secretValue
+        propertySource.get(secretName) instanceof byte[]
+        new String((byte[]) propertySource.get(secretName)) == secretValue
 
         cleanup:
         ctx.close()

--- a/test-suite-java/src/test/java/example/VaultTest.java
+++ b/test-suite-java/src/test/java/example/VaultTest.java
@@ -53,7 +53,9 @@ class VaultTest {
         OracleCloudVaultConfigurationClient client = context.getBean(OracleCloudVaultConfigurationClient.class);
         PropertySource propertySource = Flux.from(client.getPropertySources(null)).blockFirst();
         Assertions.assertNotNull(propertySource);
-        Assertions.assertEquals(secretValue, propertySource.get(secretName));
+        Object value = propertySource.get(secretName);
+        Assertions.assertTrue(value instanceof byte[]);
+        Assertions.assertEquals(secretValue, new String((byte[]) value));
         context.close();
     }
 


### PR DESCRIPTION
We can't always assume secret values are strings