### PR TITLE
Fix dependency graph to not use generated common module

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.ocisdk-metadata-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.ocisdk-metadata-module.gradle
@@ -92,7 +92,7 @@ configurations.all {
                     rs.dependencySubstitution {
                         substitute(platform(requested)).using(platform(project(":micronaut-oraclecloud-bom")))
                     }
-                } else {
+                } else if (!requested.module.contains("-common")) {
                     useTarget(project(":micronaut-oraclecloud-bmc-${simpleName}"))
                 }
             }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-base.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation mnTest.micronaut.test.junit5
     testRuntimeOnly libs.junit.jupiter
     testAnnotationProcessor mn.micronaut.inject.java
-    testRuntimeOnly mn.micronaut.jackson.databind
+    testRuntimeOnly mnSerde.micronaut.serde.jackson
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-example.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-example.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation mnValidation.micronaut.validation
     implementation projects.micronautOraclecloudSdk
     testImplementation mn.micronaut.http.client
-    testRuntimeOnly mn.micronaut.jackson.databind
+    testRuntimeOnly mnSerde.micronaut.serde.jackson
 }
 
 if (JavaVersion.current().isCompatibleWith(JavaVersion.toVersion(19))) {

--- a/oraclecloud-function-http/build.gradle
+++ b/oraclecloud-function-http/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation mnReactor.micronaut.reactor
     testImplementation mn.micronaut.http.client
     testImplementation mnTest.micronaut.test.spock
+    testImplementation "ch.qos.logback:logback-classic:1.4.7"
     testImplementation projects.micronautOraclecloudFunctionHttpTest
 }
 

--- a/oraclecloud-function-http/src/test/groovy/io/micronaut/oraclecloud/function/http/MockFnHttpServerSpec.groovy
+++ b/oraclecloud-function-http/src/test/groovy/io/micronaut/oraclecloud/function/http/MockFnHttpServerSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.oraclecloud.function.http
 
+import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
@@ -23,7 +24,7 @@ class MockFnHttpServerSpec extends Specification {
 
     void "test env forwarded"() {
         given:
-        def response = Mono.from(client.exchange(HttpRequest.GET("/"), Set<String>)).block()
+        def response = Mono.from(client.exchange(HttpRequest.GET("/"), Argument.setOf(String))).block()
 
         expect:
         response.status == HttpStatus.OK

--- a/oraclecloud-function-http/src/test/java/io/micronaut/oraclecloud/function/http/Person.java
+++ b/oraclecloud-function-http/src/test/java/io/micronaut/oraclecloud/function/http/Person.java
@@ -1,5 +1,6 @@
 package io.micronaut.oraclecloud.function.http;
 
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.Introspected;
 
 @Introspected
@@ -11,6 +12,7 @@ public class Person {
         this.name = name;
     }
 
+    @Creator
     public Person(String name, int age) {
         this.name = name;
         this.age = age;

--- a/oraclecloud-function-http/src/test/resources/logback.xml
+++ b/oraclecloud-function-http/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     </root>
 
     <!-- <logger name="io.micronaut.servlet" level="trace" /> -->
-    <!-- <logger name="io.micronaut.http.client" level="trace" /> -->
+     <logger name="io.micronaut.http.client" level="trace" />
      <logger name="io.micronaut.oraclecloud" level="trace" />
      <logger name="com.fnproject" level="trace" />
 

--- a/oraclecloud-httpclient-netty/build.gradle
+++ b/oraclecloud-httpclient-netty/build.gradle
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     annotationProcessor mnSerde.micronaut.serde.processor
     implementation mn.netty.codec.http
+
     implementation libs.oci.common
     api libs.oci.common.httpclient
     api mnSerde.micronaut.serde.api
@@ -20,11 +21,14 @@ dependencies {
 
     testAnnotationProcessor mn.micronaut.inject.java
     testAnnotationProcessor projects.micronautOraclecloudSerdeProcessor
+    testRuntimeOnly mn.micronaut.jackson.databind
+    testRuntimeOnly mn.micronaut.runtime
 
     testImplementation mn.micronaut.inject.java.test
     testImplementation mnSerde.micronaut.serde.processor
     testImplementation projects.micronautOraclecloudSerdeProcessor
     testImplementation mn.micronaut.management
+    testImplementation mn.micronaut.context
 
     [projects.micronautOraclecloudBmcMonitoring,
      projects.micronautOraclecloudBmcIdentity,

--- a/settings-build-logic/src/main/kotlin/io/micronaut/internal/settings/ProjectImporter.kt
+++ b/settings-build-logic/src/main/kotlin/io/micronaut/internal/settings/ProjectImporter.kt
@@ -156,7 +156,6 @@ private fun parseDependencies(dependenciesNode: Node?, properties: Map<String, S
         if (groupId != null && artifactId != null) {
             if (groupId == SDK_GROUP_ID && artifactId.startsWith(OCI_SDK_ARTIFACTID_PREFIX) && !artifactId.contains("-common")) {
                 val projectPath = ":${PROJECT_NAME_PREFIX}${artifactId.substringAfter(OCI_SDK_ARTIFACTID_PREFIX)}"
-                println("Add $projectPath for $artifactId")
                 result.add(Dependency.Project(projectPath, scope))
             } else {
                 val fixedVersion = if (version.startsWith("\${")) {

--- a/settings-build-logic/src/main/kotlin/io/micronaut/internal/settings/ProjectImporter.kt
+++ b/settings-build-logic/src/main/kotlin/io/micronaut/internal/settings/ProjectImporter.kt
@@ -71,9 +71,9 @@ private fun Settings.importProject(
                             val moduleName = PROJECT_NAME_PREFIX + moduleArtifactId.substringAfter(OCI_SDK_ARTIFACTID_PREFIX)
                             if (!moduleName.contains("examples") &&
                                 !moduleName.contains("-addons") &&
-                                !moduleName.contains("-commons") &&
+                                !moduleName.contains("-common") &&
                                 !moduleName.endsWith("-enforcer-rules") &&
-                            !moduleName.endsWith("-full")) {
+                                !moduleName.endsWith("-full")) {
                                 include(":$moduleName")
                                 project(":$moduleName").setProjectDir(projectDir)
                                 configureProject(moduleName, doc, properties, constraints, Dependency.External(parentGroupId, moduleArtifactId, parentVersion, null))
@@ -154,8 +154,9 @@ private fun parseDependencies(dependenciesNode: Node?, properties: Map<String, S
         val version = findFirst("version")?.textContent ?: ""
         val scope = findFirst("scope")?.textContent
         if (groupId != null && artifactId != null) {
-            if (groupId == SDK_GROUP_ID && artifactId.startsWith(OCI_SDK_ARTIFACTID_PREFIX)) {
+            if (groupId == SDK_GROUP_ID && artifactId.startsWith(OCI_SDK_ARTIFACTID_PREFIX) && !artifactId.contains("-common")) {
                 val projectPath = ":${PROJECT_NAME_PREFIX}${artifactId.substringAfter(OCI_SDK_ARTIFACTID_PREFIX)}"
+                println("Add $projectPath for $artifactId")
                 result.add(Dependency.Project(projectPath, scope))
             } else {
                 val fixedVersion = if (version.startsWith("\${")) {

--- a/test-suite-java/build.gradle
+++ b/test-suite-java/build.gradle
@@ -3,6 +3,10 @@ plugins {
 }
 
 mainClassName = "helloworld.Application"
+// ensure Jackson databind is not on the classpath for tests
+configurations.all {
+    exclude(group:"com.fasterxml.jackson.core", module:"jackson-databind")
+}
 dependencies {
     implementation(platform(libs.oci.bom))
     implementation mnSerde.micronaut.serde.jackson


### PR DESCRIPTION
Currently we are producing a synthetic module for `bmc-common` which is unnecessary and in fact is including jersey in the final dependency graph. This fixes that.