### PR TITLE
Switch micronaut-jackson-databind to compileOnly

### DIFF
--- a/oraclecloud-function/build.gradle
+++ b/oraclecloud-function/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api libs.fn.api
     api mn.micronaut.function
     api projects.micronautOraclecloudCommon
-    implementation mn.micronaut.jackson.databind
+    compileOnly mn.micronaut.jackson.databind
     compileOnly libs.graal.svm
     testImplementation libs.oci.objectstorage
     testImplementation libs.fn.testing.junit4


### PR DESCRIPTION
Switches micronaut-jackson-databind dependency to compileOnly in `micronaut-oraclecloud-function` module