### PR TITLE
Enable binary compatibility checks.

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-module.gradle
@@ -10,3 +10,11 @@ dependencies {
 configurations.all {
     resolutionStrategy.preferProjectModules()
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = true
+        // TODO required for now. Remove after Micronaut 4 release
+        baselineVersion = "3.0.0-M13"
+    }
+}

--- a/oraclecloud-certificates/build.gradle
+++ b/oraclecloud-certificates/build.gradle
@@ -15,12 +15,3 @@ dependencies {
     testImplementation mn.micronaut.http.client
     testImplementation mn.micronaut.inject.groovy
 }
-
-micronautBuild {
-    def simpleVersion = version
-    if (version.contains('-')) {
-        simpleVersion = version.substring(0, version.indexOf('-'))
-    }
-    def (String major, String minor, String patch) = simpleVersion.split("[.]")
-    binaryCompatibility.enabled = major.toInteger() >=3 && minor.toInteger() >= 1 && patch.toInteger() > 0
-}


### PR DESCRIPTION
binary compatibility checks are still disabled in `buildSrc/src/main/groovy/io.micronaut.build.internal.ocisdk-metadata-module.gradle`. I'm not sure if they should be, and if they shouldn’t be, I'm not sure how to make it work.