### PR TITLE
#669 Fix serde import of additional models

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.0.0"
+micronaut = "4.0.4"
 micronaut-platform = "4.0.0-RC1"
 micronaut-docs = "2.0.0"
 fn = '1.0.175'

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.oraclecloud.serde;
 
+import com.oracle.bmc.auth.internal.GetResourcePrincipalSessionTokenRequest;
+import com.oracle.bmc.auth.internal.JWK;
+import com.oracle.bmc.auth.internal.X509FederationClient;
 import com.oracle.bmc.http.client.Serializer;
 import com.oracle.bmc.http.internal.ResponseHelper;
 import com.oracle.bmc.model.RegionSchema;
@@ -32,8 +35,12 @@ import java.util.Map;
  * configured for use inside an Oracle Cloud SDK HTTP client.
  */
 @Internal
-@SerdeImport(ResponseHelper.ErrorCodeAndMessage.class)
+@SerdeImport(GetResourcePrincipalSessionTokenRequest.class)
+@SerdeImport(JWK.class)
 @SerdeImport(RegionSchema.class)
+@SerdeImport(ResponseHelper.ErrorCodeAndMessage.class)
+@SerdeImport(X509FederationClient.SecurityToken.class)
+@SerdeImport(X509FederationClient.X509FederationRequest.class)
 public final class OciSdkMicronautSerializer implements Serializer {
 
     private static final Map<String, Object> DEFAULT_MAPPER_CONFIG = Map.of(

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serde/AdditionalModelsSerdeSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serde/AdditionalModelsSerdeSpec.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.oraclecloud.serde
+
+import com.oracle.bmc.auth.internal.GetResourcePrincipalSessionTokenRequest
+import com.oracle.bmc.auth.internal.JWK
+import com.oracle.bmc.auth.internal.X509FederationClient
+import com.oracle.bmc.model.RegionSchema
+import io.micronaut.runtime.server.EmbeddedServer
+
+class AdditionalModelsSerdeSpec extends SerdeSpecBase {
+
+    void "test additional models are serdeable"() {
+        given:
+        EmbeddedServer embeddedServer = initContext()
+
+        expect:
+        json == echoTest(embeddedServer, value)
+
+        when:
+        echoTest(embeddedServer, json, value.getClass())
+
+        then:
+        noExceptionThrown()
+
+        where:
+        value | json
+        new RegionSchema("key", "comp", "region key", "identifier")
+              | '{"realmKey":"key","realmDomainComponent":"comp","regionKey":"region key","regionIdentifier":"identifier"}'
+        new GetResourcePrincipalSessionTokenRequest("token", "session token", "pk")
+              | '{"resourcePrincipalToken":"token","servicePrincipalSessionToken":"session token","sessionPublicKey":"pk"}'
+        new X509FederationClient.X509FederationRequest("key", "cert", [] as Set, "purple", "alg")
+              | '{"intermediateCertificates":[],"certificate":"cert","publicKey":"key","purpose":"purple","fingerprintAlgorithm":"alg"}'
+        new X509FederationClient.SecurityToken("my token")
+              | '{"token":"my token"}'
+        new JWK("some id", "some n", "some e")
+              | '{"kty":"RSA","use":"sig","alg":"RS256","kid":"some id","n":"some n","e":"some e"}'
+    }
+
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serde/RegionsClientSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/serde/RegionsClientSpec.groovy
@@ -1,0 +1,55 @@
+package io.micronaut.oraclecloud.serde
+
+import com.oracle.bmc.Region
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.exceptions.HttpStatusException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
+
+@MicronautTest
+class RegionsClientSpec extends SerdeSpecBase {
+
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void "test region from imds deserialization"() {
+        given:
+        var server = initContext()
+
+        when:
+        // fail once, it should retry
+        Region region = Region.getRegionFromImds(server.getURL().toString() + "/opc/v2/");
+
+        then:
+        "123" == region.regionId
+        "123" == region.regionCode
+        "ocxyz" == region.realm.realmId
+        "ocxyz.example.com" == region.realm.secondLevelDomain
+    }
+
+    @Controller("/opc/v2/instance/regionInfo")
+    static class RegionController {
+
+        private static numCalled = 0;
+
+        @Get
+        String getRegionInfo(HttpRequest<?> request) {
+            if (request.headers.get("Authorization") != "Bearer Oracle") {
+                return null
+            }
+
+            numCalled++
+            if (numCalled < 3) {
+                throw new HttpStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error")
+            }
+            return '{"realmKey":"ocxyz",' +
+                    '"realmDomainComponent":"ocxyz.example.com",' +
+                    '"regionIdentifier": "123",' +
+                    '"regionKey": "123"}'
+        }
+    }
+
+}

--- a/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/OciSdkModelSerdeVisitor.java
+++ b/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/OciSdkModelSerdeVisitor.java
@@ -33,7 +33,6 @@ import io.micronaut.serde.config.annotation.SerdeConfig;
 
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Type element visitor vising oci sdk models and enums.
@@ -52,12 +51,6 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
     private static final String OCI_SDK_ENUM_CLASS_NAME = "com.oracle.bmc.http.internal.BmcEnum";
     private static final String OCI_SDK_ENUM_CREATOR_NAME = "create";
     private static final String INTROSPECTION_PACKAGE = ".introspection";
-
-    private static final Set<String> ADDITIONAL_MODELS = Set.of(
-        "com.oracle.bmc.http.internal.ResponseHelper$ErrorCodeAndMessage",
-        "com.oracle.bmc.model.RegionSchema",
-        "com.oracle.bmc.auth.internal.X509FederationClient$SecurityToken"
-    );
 
     private boolean visitingOciSdkModel;
     private boolean visitingOciSdkEnum;
@@ -150,8 +143,7 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
             }
             parent = parent.get().getSuperType();
         }
-
-        return ADDITIONAL_MODELS.contains(element.getName());
+        return false;
     }
 
     private static boolean isOciSdkEnum(ClassElement element) {


### PR DESCRIPTION
- Use serde import directly in the client module for importing additional models, as all of them are located in the oci sdk common module and the previous approach did not work for all models correctly.
- Serde import missing models that require serialization.