### PR TITLE
Add @Requires to oracle cloud logging

### DIFF
--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
@@ -20,6 +20,7 @@ import com.oracle.bmc.loggingingestion.requests.PutLogsRequest;
 import com.oracle.bmc.loggingingestion.responses.PutLogsResponse;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
@@ -38,10 +39,11 @@ import jakarta.inject.Singleton;
 @Context
 @Internal
 @Singleton
+@Requires(bean=Logging.class)
+@Requires(property = OracleCloudLoggingClient.ENABLED, value = "true", defaultValue = "true")
 final class OracleCloudLoggingClient implements ApplicationEventListener<ServerStartupEvent> {
-
     public static final String PREFIX = OracleCloudCoreFactory.ORACLE_CLOUD + ".logging";
-
+    public static final String ENABLED = PREFIX + ".enabled";
     private static Logging logging;
     private static String host;
     private static String appName;

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.oraclecloud.logging
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.env.Environment
+import spock.lang.Specification
+
+@Property(name = "spec.name", value = "OracleCloudLoggingClientSpec")
+class OracleCloudLoggingClientSpec extends Specification {
+
+    def "test it not loads when globally disabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "oci.logging.enabled": "false",
+        ], Environment.ORACLE_CLOUD)
+
+        expect:
+        !context.containsBean(OracleCloudLoggingClient)
+    }
+
+
+}


### PR DESCRIPTION
- Adds `@Requires(bean=Logging.class)` annotation to OracleCloudLoggingClient.
- Requires that `oci.logging.enabled` to be true so it can be disabled manually.