### PR TITLE
#696 increase jdk.jar.maxSignatureFileSize system property value to resolve javadoc error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ githubSlug=micronaut-projects/micronaut-oracle-cloud
 developers=Graeme Rocher
 
 
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g -Xmx2g
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g -Xmx2g -Djdk.jar.maxSignatureFileSize=16000000
 ocidocs=https://docs.oracle.com/en-us/iaas/tools/java/2.2.0/
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
Increased ` jdk.jar.maxSignatureFileSize` system property to resolve 
`error: error reading /home/runner/.gradle/caches/modules-2/files-2.1/com.oracle.o***.sdk/o***-java-sdk-shaded-full/3.15.0/b5fb2200899542f281e2ca4238ba3c9dc288c30d/o***-java-sdk-shaded-full-3.15.0.jar; Unsupported size: 9315035 for JarEntry META-INF/MANIFEST.MF. Allowed max size: 8000000 bytes` error (for example at https://github.com/micronaut-projects/micronaut-oracle-cloud/actions/runs/6143620216/job/16667430651).
This property's default value, which is currently 8MB, should be increased to 16MB in future JDK builds(https://bugs.openjdk.org/browse/JDK-8312489)