### PR TITLE
increase jdk.jar.maxSignatureFileSize system property value (#696)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,12 +59,12 @@ jobs:
           [ -f ./setup.sh ] && ./setup.sh || [ ! -f ./setup.sh ]
 
       - name: "📑 Javadoc"
-        id: gradle
+        id: javadoc
         run: |
           ./gradlew javadoc
 
       - name: "📃 docs"
-        id: gradle
+        id: docs
         run: |
           ./gradlew docs
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'io.micronaut.build.internal.quality-reporting'
 }
 
+tasks.withType(Javadoc) {
+    options.jFlags("-Djdk.jar.maxSignatureFileSize=16000000")
+}
+
 repositories {
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'io.micronaut.build.internal.quality-reporting'
 }
 
-tasks.withType(Javadoc) {
+tasks.withType(Javadoc).configureEach {
     options.jFlags("-Djdk.jar.maxSignatureFileSize=16000000")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ githubSlug=micronaut-projects/micronaut-oracle-cloud
 developers=Graeme Rocher
 
 
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g -Xmx2g -Djdk.jar.maxSignatureFileSize=16000000
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g -Xmx2g
 ocidocs=https://docs.oracle.com/en-us/iaas/tools/java/2.2.0/
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
Increased `jdk.jar.maxSignatureFileSize` system property to resolve
`error: error reading /home/runner/.gradle/caches/modules-2/files-2.1/com.oracle.o***.sdk/o***-java-sdk-shaded-full/3.15.0/b5fb2200899542f281e2ca4238ba3c9dc288c30d/o***-java-sdk-shaded-full-3.15.0.jar; Unsupported size: 9315035 for JarEntry META-INF/MANIFEST.MF. Allowed max size: 8000000 bytes` error .
This property's default value, which is currently 8MB, should be increased to 16MB in future JDK builds(https://bugs.openjdk.org/browse/JDK-8312489)