### PR TITLE
add faultDomain to instance metadata

### DIFF
--- a/oraclecloud-common/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudInstanceMetadata.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudInstanceMetadata.java
@@ -31,15 +31,23 @@ public class OracleCloudInstanceMetadata extends AbstractComputeInstanceMetadata
 
     private final ComputePlatform computePlatform = ComputePlatform.ORACLE_CLOUD;
 
+    private String faultDomain;
+
+    /**
+     * Getter for faultDomain.
+     * @return returns the instance metadata faultDomain
+     */
     public String getFaultDomain() {
         return faultDomain;
     }
 
+    /**
+     * Setter for faultDomain.
+     * @param faultDomain The faultDomain from instance metadata
+     */
     public void setFaultDomain(String faultDomain) {
         this.faultDomain = faultDomain;
     }
-
-    private String faultDomain;
 
     @Override
     @JsonIgnore

--- a/oraclecloud-common/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudInstanceMetadata.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudInstanceMetadata.java
@@ -31,6 +31,16 @@ public class OracleCloudInstanceMetadata extends AbstractComputeInstanceMetadata
 
     private final ComputePlatform computePlatform = ComputePlatform.ORACLE_CLOUD;
 
+    public String getFaultDomain() {
+        return faultDomain;
+    }
+
+    public void setFaultDomain(String faultDomain) {
+        this.faultDomain = faultDomain;
+    }
+
+    private String faultDomain;
+
     @Override
     @JsonIgnore
     public ComputePlatform getComputePlatform() {

--- a/oraclecloud-common/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataResolver.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataResolver.java
@@ -44,6 +44,7 @@ import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.A
 import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.AVAILABILITY_DOMAIN;
 import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.CANONICAL_REGION_NAME;
 import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.DISPLAY_NAME;
+import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.FAULT_DOMAIN;
 import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.ID;
 import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.IMAGE;
 import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.MAC;
@@ -120,6 +121,7 @@ public class OracleCloudMetadataResolver implements ComputeInstanceMetadataResol
                 instanceMetadata.setAvailabilityZone(textValue(metadataJson, AVAILABILITY_DOMAIN));
                 instanceMetadata.setImageId(textValue(metadataJson, IMAGE));
                 instanceMetadata.setMachineType(textValue(metadataJson, SHAPE));
+                instanceMetadata.setFaultDomain(textValue(metadataJson, FAULT_DOMAIN));
 
                 Map<String, String> metadata = jsonMapper.readValueFromTree(metadataJson, Map.class);
 

--- a/oraclecloud-common/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudMetadataResolverSpec.groovy
+++ b/oraclecloud-common/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudMetadataResolverSpec.groovy
@@ -40,6 +40,7 @@ class OracleCloudMetadataResolverSpec extends Specification {
         computeInstanceMetadata.get().instanceId == "ocid1.instance.oc1.phx.abyhqljrg2v5zuydab6r5nbsywedkjvtwd57opwmuhfc5hg5jrxgs3jmg3ga"
         computeInstanceMetadata.get().name == "micronaut-env"
         computeInstanceMetadata.get().region == "us-phoenix-1"
+        computeInstanceMetadata.get().faultDomain == "FAULT-DOMAIN-2"
     }
 
     private OracleCloudMetadataResolver buildResolver() {

--- a/oraclecloud-oke-workload-identity/src/main/java/io/micronaut/oraclecloud/oke/workload/identity/MicronautOkeWorkloadIdentityAuthenticationDetailsProviderBuilder.java
+++ b/oraclecloud-oke-workload-identity/src/main/java/io/micronaut/oraclecloud/oke/workload/identity/MicronautOkeWorkloadIdentityAuthenticationDetailsProviderBuilder.java
@@ -27,7 +27,6 @@ import com.oracle.bmc.http.client.StandardClientProperties;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 /** Builder for OkeWorkloadIdentityAuthenticationDetailsProviderBuilder. */
 class MicronautOkeWorkloadIdentityAuthenticationDetailsProviderBuilder extends OkeWorkloadIdentityAuthenticationDetailsProvider.OkeWorkloadIdentityAuthenticationDetailsProviderBuilder {


### PR DESCRIPTION
PR adds `faultDomain` field type `String` to the OCI Instance metadata