### PR TITLE
Use ObjectMapper from context

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.2.0"
+micronaut = "4.2.2"
 micronaut-platform = "4.1.6"
 micronaut-docs = "2.0.0"
 fn = '1.0.180'
@@ -25,7 +25,7 @@ micronaut-kotlin = "4.1.0"
 micronaut-micrometer = "5.2.0"
 micronaut-reactor = "3.1.0"
 micronaut-rxjava2 = "2.1.0"
-micronaut-serde = "2.4.0"
+micronaut-serde = "2.7.0"
 micronaut-servlet = "4.2.1"
 micronaut-sql = "5.2.0"
 micronaut-test = "4.1.0"

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
@@ -26,6 +26,8 @@ import com.oracle.bmc.http.client.StandardClientProperties;
 import io.micronaut.http.client.DefaultHttpClientConfiguration;
 import io.micronaut.http.client.netty.ConnectionManager;
 import io.micronaut.http.client.netty.DefaultHttpClient;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.oraclecloud.serde.OciSdkMicronautSerializer;
 import io.netty.buffer.ByteBufAllocator;
 
 import java.io.Closeable;
@@ -58,6 +60,7 @@ final class NettyHttpClient implements HttpClient {
     final Closeable upstreamHttpClient;
     final ConnectionManager connectionManager;
     final DefaultHttpClient.RequestKey requestKey;
+    final JsonMapper jsonMapper;
 
     static {
         ClientConfiguration cfg = ClientConfiguration.builder().build();
@@ -81,6 +84,7 @@ final class NettyHttpClient implements HttpClient {
             }
             mnClient = new DefaultHttpClient((URI) null, cfg);
             blockingIoExecutor = Executors.newCachedThreadPool();
+            jsonMapper = OciSdkMicronautSerializer.getDefaultObjectMapper();
         } else {
             hasContext = true;
             for (Map.Entry<ClientProperty<?>, Object> entry : builder.properties.entrySet()) {
@@ -90,6 +94,7 @@ final class NettyHttpClient implements HttpClient {
             }
             mnClient = (DefaultHttpClient) builder.managedProvider.mnHttpClient;
             blockingIoExecutor = builder.managedProvider.ioExecutor;
+            jsonMapper = builder.managedProvider.jsonMapper;
         }
         upstreamHttpClient = mnClient;
         connectionManager = mnClient.connectionManager();

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
@@ -20,7 +20,6 @@ import com.oracle.bmc.http.client.HttpResponse;
 import com.oracle.bmc.http.client.Method;
 import com.oracle.bmc.http.client.RequestInterceptor;
 import io.micronaut.http.client.netty.ConnectionManager;
-import io.micronaut.oraclecloud.serde.OciSdkMicronautSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
@@ -127,7 +126,7 @@ final class NettyHttpRequest implements HttpRequest {
             //  anything but String
             String json;
             try {
-                json = OciSdkMicronautSerializer.getDefaultObjectMapper().writeValueAsString(body);
+                json = client.jsonMapper.writeValueAsString(body);
             } catch (IOException e) {
                 throw new IllegalArgumentException("Unable to process JSON body", e);
             }
@@ -382,7 +381,7 @@ final class NettyHttpRequest implements HttpRequest {
                                     skipLast = true;
                                 }
                             } else {
-                                future.complete(new NettyHttpResponse(response, limitedBufferingBodyHandler, undecidedBodyHandler, offloadExecutor));
+                                future.complete(new NettyHttpResponse(client.jsonMapper, response, limitedBufferingBodyHandler, undecidedBodyHandler, offloadExecutor));
                                 ctx.pipeline().remove(this);
                             }
 

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
@@ -49,20 +49,6 @@ import java.util.Map;
 @SerdeImport(OkeResourcePrincipalSessionToken.class)
 public final class OciSdkMicronautSerializer implements Serializer {
 
-    private static final Map<String, Object> DEFAULT_MAPPER_CONFIG = Map.of(
-        "micronaut.serde.writeDatesAsTimestamps", false,
-        "micronaut.serde.write-binary-as-array", false,
-        "micronaut.serde.serialization.inclusion", SerdeConfig.SerInclude.NON_NULL
-    );
-
-    private static final ObjectMapper DEFAULT_MAPPER = ObjectMapper.create(
-        DEFAULT_MAPPER_CONFIG,
-        "io.micronaut.oraclecloud.serde.filter",
-        "io.micronaut.oraclecloud.serde.serializers"
-    );
-
-    private static final Serializer DEFAULT_SERIALIZER = new OciSdkMicronautSerializer(DEFAULT_MAPPER);
-
     private final JsonMapper objectMapper;
 
     /**
@@ -92,13 +78,31 @@ public final class OciSdkMicronautSerializer implements Serializer {
      * @return The implementation of object mapper configured for oci java sdk
      */
     public static ObjectMapper getDefaultObjectMapper() {
-        return DEFAULT_MAPPER;
+        return UnmanagedSerializerHolder.DEFAULT_MAPPER;
     }
 
     /**
      * @return The implementation of serializer configured for oci java sdk
      */
     public static Serializer getDefaultSerializer() {
-        return DEFAULT_SERIALIZER;
+        return UnmanagedSerializerHolder.DEFAULT_SERIALIZER;
+    }
+
+    private static class UnmanagedSerializerHolder {
+        // only initialize if necessary
+
+        private static final Map<String, Object> DEFAULT_MAPPER_CONFIG = Map.of(
+            "micronaut.serde.writeDatesAsTimestamps", false,
+            "micronaut.serde.write-binary-as-array", false,
+            "micronaut.serde.serialization.inclusion", SerdeConfig.SerInclude.NON_NULL
+        );
+
+        private static final ObjectMapper DEFAULT_MAPPER = ObjectMapper.create(
+            DEFAULT_MAPPER_CONFIG,
+            "io.micronaut.oraclecloud.serde.filter",
+            "io.micronaut.oraclecloud.serde.serializers"
+        );
+
+        private static final Serializer DEFAULT_SERIALIZER = new OciSdkMicronautSerializer(DEFAULT_MAPPER);
     }
 }

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
@@ -24,6 +24,7 @@ import com.oracle.bmc.http.client.Serializer;
 import com.oracle.bmc.http.internal.ResponseHelper;
 import com.oracle.bmc.model.RegionSchema;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.annotation.SerdeImport;
 import io.micronaut.serde.config.annotation.SerdeConfig;
@@ -62,13 +63,13 @@ public final class OciSdkMicronautSerializer implements Serializer {
 
     private static final Serializer DEFAULT_SERIALIZER = new OciSdkMicronautSerializer(DEFAULT_MAPPER);
 
-    private final ObjectMapper objectMapper;
+    private final JsonMapper objectMapper;
 
     /**
      * Create Serializer from micronaut serde {@link ObjectMapper}.
      * @param objectMapper the object mapper
      */
-    public OciSdkMicronautSerializer(ObjectMapper objectMapper) {
+    public OciSdkMicronautSerializer(JsonMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerdeConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerdeConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serde;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.serde.config.SerdeConfiguration;
+
+@ConfigurationProperties("oci.serde")
+@Bean(typed = OciSerdeConfiguration.class)
+@Internal
+public interface OciSerdeConfiguration extends SerdeConfiguration {
+    @Override
+    @Bindable(defaultValue = "false")
+    boolean isWriteBinaryAsArray();
+}

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerializationConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerializationConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serde;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.serde.config.SerializationConfiguration;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+@ConfigurationProperties("oci.serde.serialization")
+@Bean(typed = OciSerializationConfiguration.class)
+@Internal
+public interface OciSerializationConfiguration extends SerializationConfiguration {
+    @Bindable(defaultValue = "NON_NULL")
+    @Override
+    SerdeConfig.SerInclude getInclusion();
+}

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/ManagedTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/ManagedTest.java
@@ -10,8 +10,10 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
-import io.micronaut.json.JsonMapper;
+import io.micronaut.oraclecloud.serde.OciSerdeConfiguration;
+import io.micronaut.oraclecloud.serde.OciSerializationConfiguration;
 import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.serde.ObjectMapper;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -43,8 +45,8 @@ public class ManagedTest {
     public static class MockProvider extends ManagedNettyHttpProvider {
         int buildersCreated = 0;
 
-        public MockProvider(@Client(id = SERVICE_ID) HttpClient mnHttpClient, @Named(TaskExecutors.BLOCKING) ExecutorService ioExecutor, JsonMapper jsonMapper) {
-            super(mnHttpClient, ioExecutor, jsonMapper);
+        public MockProvider(@Client(id = SERVICE_ID) HttpClient mnHttpClient, @Named(TaskExecutors.BLOCKING) ExecutorService ioExecutor, ObjectMapper jsonMapper, OciSerdeConfiguration ociSerdeConfiguration, OciSerializationConfiguration ociSerializationConfiguration) {
+            super(mnHttpClient, ioExecutor, jsonMapper, ociSerdeConfiguration, ociSerializationConfiguration);
         }
 
         @Override

--- a/oraclecloud-oke-workload-identity/src/main/java/io/micronaut/oraclecloud/oke/workload/identity/MicronautOkeWorkloadIdentityResourcePrincipalsFederationClient.java
+++ b/oraclecloud-oke-workload-identity/src/main/java/io/micronaut/oraclecloud/oke/workload/identity/MicronautOkeWorkloadIdentityResourcePrincipalsFederationClient.java
@@ -171,7 +171,7 @@ final class MicronautOkeWorkloadIdentityResourcePrincipalsFederationClient exten
             return null;
         }
 
-        HttpClientBuilder rptBuilder = new ManagedNettyHttpProvider(defaultHttpClient(), Executors.newCachedThreadPool(),  JsonMapper.createDefault())
+        HttpClientBuilder rptBuilder = new ManagedNettyHttpProvider(defaultHttpClient(), Executors.newCachedThreadPool())
                 .newBuilder()
                 .baseUri(URI.create(endpoint))
                 .registerRequestInterceptor(


### PR DESCRIPTION
Use the new serde clone API to use the ObjectMapper from the BeanContext for ManagedNettyHttpProvider. This allows adding custom serdes to the mapper.

Jackson remains unsupported for now, because there is no central cloneWithConfiguration API atm.

Fixes #647