### PR TITLE
OracleCloud MeterRegistry with raw data

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Field $ANNOTATION_METADATA",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Constructor io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference()",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.core.annotation.AnnotationSource",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.inject.BeanContextConditional",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.core.annotation.AnnotationMetadataProvider",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.core.beans.BeanInfo",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.core.annotation.AnnotationMetadataDelegate",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.core.annotation.AnnotationMetadata",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.inject.QualifiedBeanType",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.core.type.ArgumentCoercible",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.inject.BeanType",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  },
+  {
+    "type": "io.micronaut.oraclecloud.monitoring.$OracleCloudMeterRegistryFactory$OracleCloudMeterRegistry0$Definition$Reference",
+    "member": "Implemented interface io.micronaut.inject.BeanDefinitionReference",
+    "reason": "Introduction of the OracleCloudRawMeterRegistry. The default is still OracleCloudMeterRegistry. Refactor of the OracleCloudMeterRegistryFactory"
+  }
+]

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -91,7 +91,7 @@ public class OracleCloudMeterRegistryFactory {
      *
      * @param oracleCloudConfig the OracleCloudConfig configuration
      * @param monitoringIngestionClient     the monitoring ingestion client
-     * @return A OracleCloudMeterRegistry
+     * @return the registry
      */
     @Singleton
     @Bean(preDestroy = "close")

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -65,7 +65,7 @@ public class OracleCloudMeterRegistryFactory {
     }
 
     /**
-     * Create a OracleCloudConfig bean if global metrics are enabled.
+     * Create an OracleCloudConfig bean if global metrics are enabled.
      * @param exportConfigurationProperties the exportConfigurationProperties configuration
      * @return A OracleCloudConfig
      */
@@ -85,7 +85,7 @@ public class OracleCloudMeterRegistryFactory {
     }
 
     /**
-     * Create a OracleCloudMeterRegistry bean if global metrics are enabled,
+     * Create an OracleCloudMeterRegistry bean if global metrics are enabled,
      * the oraclecloudmonitoring is enabled and raw metrics disabled.
      * Will be true by default when this configuration is included in project.
      *
@@ -110,7 +110,7 @@ public class OracleCloudMeterRegistryFactory {
      *
      * @param oracleCloudConfig the OracleCloudConfig configuration
      * @param monitoringIngestionClient     the monitoring ingestion client
-     * @return A oracleCloudRawMeterRegistry
+     * @return the registry
      */
     @Singleton
     @Bean(preDestroy = "close")

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.monitoring.micrometer;
+
+import com.oracle.bmc.monitoring.MonitoringClient;
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
+import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.core.lang.Nullable;
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
+    protected final OracleCloudConfig oracleCloudConfig;
+    private final Logger logger = LoggerFactory.getLogger(AbstractOracleCloudMeterRegistry.class);
+    private final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(OracleCloudMetricsNamingConvention.class);
+    private final MonitoringClient monitoringClient;
+
+    public AbstractOracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig, Clock clock, MonitoringClient monitoringClient, ThreadFactory threadFactory) {
+        super(oracleCloudConfig, clock);
+        this.monitoringClient = monitoringClient;
+        this.oracleCloudConfig = oracleCloudConfig;
+        config().namingConvention(new OracleCloudMetricsNamingConvention());
+        config().commonTags("application", this.oracleCloudConfig.applicationName());
+        start(threadFactory);
+    }
+
+    @Override
+    protected TimeUnit getBaseTimeUnit() {
+        return TimeUnit.MILLISECONDS;
+    }
+
+    /**
+     * Generates metric name.
+     *
+     * @param id meter id
+     * @param suffix suffix
+     * @return metric name
+     */
+    String getMetricName(Meter.Id id, @Nullable String suffix) {
+        String name = suffix != null ? id.getName() + "_" + suffix : id.getName();
+        return config().namingConvention().name(name, id.getType(), id.getBaseUnit());
+    }
+
+    /**
+     * Transforms {@link Tag}s to dimensions. Tags that have empty key or value are ignored as
+     * they are not consider valid dimensions.
+     *
+     * @param tags tags
+     * @return map of tags
+     */
+    Map<String, String> toDimensions(List<Tag> tags) {
+        Map<String, String> m = tags.stream().
+            filter(this::isValidTag).
+            collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+        return m;
+    }
+
+    private boolean isValidTag(Tag tag) {
+        if (tag.getKey() == null || tag.getKey().length() == 0 || tag.getValue() == null || tag.getValue().length() == 0) {
+            warnThenDebugLogger.log("Tag " + tag.getKey() + " not published because tag key or value are empty.");
+            return false;
+        }
+        return true;
+    }
+
+    protected abstract List<MetricDataDetails> getMetricData();
+
+    @Override
+    protected void publish() {
+        for (List<MetricDataDetails> batch : MetricDataDetailsPartition.partition(getMetricData(), oracleCloudConfig.batchSize())) {
+            final PostMetricDataDetails.Builder builder = PostMetricDataDetails.builder()
+                .metricData(batch);
+            if (oracleCloudConfig.batchAtomicity() != null) {
+                builder.batchAtomicity(oracleCloudConfig.batchAtomicity());
+            }
+            try {
+                monitoringClient.postMetricData(PostMetricDataRequest.builder()
+                    .postMetricDataDetails(builder.build())
+                    .build());
+            } catch (Throwable e) {
+                logger.error("failed to post metrics to oracle cloud infrastructure monitoring: " + e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -81,7 +81,7 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
     }
 
     private boolean isValidTag(Tag tag) {
-        if (tag.getKey() == null || tag.getKey().length() == 0 || tag.getValue() == null || tag.getValue().length() == 0) {
+        if (StringUtils.isEmpty(tag.getKey()) || StringUtils.isEmpty(tag.getValue())) {
             warnThenDebugLogger.log("Tag " + tag.getKey() + " not published because tag key or value are empty.");
             return false;
         }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -19,6 +19,7 @@ import com.oracle.bmc.monitoring.MonitoringClient;
 import com.oracle.bmc.monitoring.model.MetricDataDetails;
 import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
 import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
+import com.oracle.bmc.util.internal.StringUtils;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
@@ -34,6 +35,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+/**
+ * Common data and functions used both by {@link OracleCloudMeterRegistry} and {@link OracleCloudRawMeterRegistry}
+ */
 abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
     protected final OracleCloudConfig oracleCloudConfig;
     private final Logger logger = LoggerFactory.getLogger(AbstractOracleCloudMeterRegistry.class);
@@ -102,7 +106,7 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
                 monitoringClient.postMetricData(PostMetricDataRequest.builder()
                     .postMetricDataDetails(builder.build())
                     .build());
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 logger.error("failed to post metrics to oracle cloud infrastructure monitoring: {}", e.getMessage(), e);
             }
         }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -44,7 +44,7 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
     private final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(OracleCloudMetricsNamingConvention.class);
     private final MonitoringClient monitoringClient;
 
-    public AbstractOracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig, Clock clock, MonitoringClient monitoringClient, ThreadFactory threadFactory) {
+    protected AbstractOracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig, Clock clock, MonitoringClient monitoringClient, ThreadFactory threadFactory) {
         super(oracleCloudConfig, clock);
         this.monitoringClient = monitoringClient;
         this.oracleCloudConfig = oracleCloudConfig;

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -103,7 +103,7 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
                     .postMetricDataDetails(builder.build())
                     .build());
             } catch (Throwable e) {
-                logger.error("failed to post metrics to oracle cloud infrastructure monitoring: " + e.getMessage(), e);
+                logger.error("failed to post metrics to oracle cloud infrastructure monitoring: {}", e.getMessage(), e);
             }
         }
     }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -197,7 +197,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
      */
     Stream<MetricDataDetails> trackRawData(Meter meter) {
         if (meter instanceof OracleCloudDatapointProducer datapointEntryProducer) {
-            return Stream.of(metricDataDetails(meter.getId(), datapointEntryProducer.produceDatapoints()));
+            return Stream.of(metricDataDetails(meter.getId(), datapointEntryProducer.getDatapoints()));
         }
         logger.error("Metrics name: %s. Haven't publish metrics for class: %s".formatted(meter.getId().toString(), meter.getClass()));
         return Stream.empty();

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,9 @@ import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudTimer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
@@ -136,7 +136,11 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
      * @return {@link MetricDataDetails} stream with meter values
      */
     Stream<MetricDataDetails> trackMeter(Meter meter) {
-        return StreamSupport.stream(meter.measure().spliterator(), false).map((ms) -> this.metricDataDetails(meter.getId().withTag(ms.getStatistic()), null, List.of(Datapoint.builder().timestamp(new Date()).value(ms.getValue()).build()))).filter(Objects::nonNull);
+        return StreamSupport.stream(
+            meter.measure().spliterator(), false).map(
+                (ms) -> this.metricDataDetails(meter.getId().withTag(ms.getStatistic()), null,
+                    List.of(Datapoint.builder().timestamp(new Date()).value(ms.getValue()).build())
+                )).filter(Objects::nonNull);
     }
 
     /**

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -180,7 +180,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
      * not a finite floating-point
      */
     Stream<MetricDataDetails> trackFunctionTimer(FunctionTimer functionTimer) {
-        return Stream.of(metricDataDetails(functionTimer.getId(), List.of(Datapoint.builder().value(functionTimer.totalTime(getBaseTimeUnit())).count(Double.valueOf(functionTimer.count()).intValue()).timestamp(new Date()).build())));
+        return Stream.of(metricDataDetails(functionTimer.getId(), List.of(Datapoint.builder().value(functionTimer.totalTime(getBaseTimeUnit())).count((int) functionTimer.count()).timestamp(new Date()).build())));
     }
 
     /**
@@ -188,7 +188,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
      * @return {@link MetricDataDetails} stream with long task timer values
      */
     Stream<MetricDataDetails> trackLongTaskTimer(LongTaskTimer longTaskTimer) {
-        return Stream.of(metricDataDetails(longTaskTimer.getId(), List.of(Datapoint.builder().value(longTaskTimer.duration(getBaseTimeUnit())).count(Double.valueOf(longTaskTimer.activeTasks()).intValue()).timestamp(new Date()).build())));
+        return Stream.of(metricDataDetails(longTaskTimer.getId(), List.of(Datapoint.builder().value(longTaskTimer.duration(getBaseTimeUnit())).count(longTaskTimer.activeTasks()).timestamp(new Date()).build())));
     }
 
     /**

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -130,10 +130,18 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
         ).collect(Collectors.toList());
     }
 
+    /**
+     * @param meter meter
+     * @return {@link MetricDataDetails} stream with meter values
+     */
     Stream<MetricDataDetails> trackMeter(Meter meter) {
         return StreamSupport.stream(meter.measure().spliterator(), false).map((ms) -> this.metricDataDetails(meter.getId().withTag(ms.getStatistic()), List.of(Datapoint.builder().timestamp(new Date()).value(ms.getValue()).build()))).filter(Objects::nonNull);
     }
 
+    /**
+     * @param gauge gauge meter
+     * @return {@link MetricDataDetails} stream with gauge values or null if gauge value is NaN
+     */
     Stream<MetricDataDetails> trackGauge(Gauge gauge) {
         Double value = gauge.value();
         if (Double.isNaN(value)) {
@@ -142,6 +150,10 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
         return Stream.of(metricDataDetails(gauge.getId(), List.of(Datapoint.builder().value(value).timestamp(new Date()).build())));
     }
 
+    /**
+     * @param timeGauge timer gauge meter
+     * @return {@link MetricDataDetails} stream with timer gauge meter values or null if gauge value is NaN
+     */
     Stream<MetricDataDetails> trackTimeGauge(TimeGauge timeGauge) {
         Double value = timeGauge.value(getBaseTimeUnit());
         if (Double.isNaN(value)) {
@@ -150,6 +162,10 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
         return Stream.of(metricDataDetails(timeGauge.getId(), List.of(Datapoint.builder().value(value).timestamp(new Date()).build())));
     }
 
+    /**
+     * @param functionCounter function counter meter
+     * @return {@link MetricDataDetails} stream with function counter gauge meter values or null if counter value is NaN
+     */
     Stream<MetricDataDetails> trackFunctionCounter(FunctionCounter functionCounter) {
         Double value = functionCounter.count();
         if (Double.isNaN(value)) {
@@ -158,14 +174,27 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
         return Stream.of(metricDataDetails(functionCounter.getId(), List.of(Datapoint.builder().value(value).timestamp(new Date()).build())));
     }
 
+    /**
+     * @param functionTimer function timer meter
+     * @return {@link MetricDataDetails} stream with function timer meter values or null if timer total time value is
+     * not a finite floating-point
+     */
     Stream<MetricDataDetails> trackFunctionTimer(FunctionTimer functionTimer) {
         return Stream.of(metricDataDetails(functionTimer.getId(), List.of(Datapoint.builder().value(functionTimer.totalTime(getBaseTimeUnit())).count(Double.valueOf(functionTimer.count()).intValue()).timestamp(new Date()).build())));
     }
 
+    /**
+     * @param longTaskTimer long task timer meter
+     * @return {@link MetricDataDetails} stream with long task timer values
+     */
     Stream<MetricDataDetails> trackLongTaskTimer(LongTaskTimer longTaskTimer) {
         return Stream.of(metricDataDetails(longTaskTimer.getId(), List.of(Datapoint.builder().value(longTaskTimer.duration(getBaseTimeUnit())).count(Double.valueOf(longTaskTimer.activeTasks()).intValue()).timestamp(new Date()).build())));
     }
 
+    /**
+     * @param meter OracleCloudDatapointProducer meter
+     * @return {@link MetricDataDetails} stream with multiple entries of {@link Datapoint}
+     */
     Stream<MetricDataDetails> trackRawData(Meter meter) {
         if (meter instanceof OracleCloudDatapointProducer datapointEntryProducer) {
             return Stream.of(metricDataDetails(meter.getId(), datapointEntryProducer.produceDatapoints()));

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.monitoring.micrometer;
+
+import com.oracle.bmc.monitoring.MonitoringClient;
+import com.oracle.bmc.monitoring.model.Datapoint;
+import com.oracle.bmc.monitoring.model.MetricDataDetails;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.HistogramGauges;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudDatapointProducer;
+import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudCounter;
+import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudDistributionSummary;
+import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudTimer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * {@link StepMeterRegistry} for Oracle Cloud Monitoring that produces raw data.
+ *
+ * @author Nemanja Mikic
+ * @since 3.6
+ */
+public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistry {
+
+    private final Logger logger = LoggerFactory.getLogger(OracleCloudRawMeterRegistry.class);
+
+    public OracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig,
+                                    Clock clock,
+                                    MonitoringClient monitoringClient) {
+        this(oracleCloudConfig, clock, monitoringClient, new NamedThreadFactory("oraclecloud-metrics-publisher"));
+    }
+
+    public OracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig,
+                                    Clock clock,
+                                    MonitoringClient monitoringClient,
+                                    ThreadFactory threadFactory) {
+        super(oracleCloudConfig, clock, monitoringClient, threadFactory);
+
+    }
+
+    /**
+     * @param id                          The id that uniquely identifies the timer.
+     * @param distributionStatisticConfig Configuration for published distribution
+     *                                    statistics.
+     * @param pauseDetector               The pause detector to use for coordinated omission
+     *                                    compensation.
+     * @return
+     */
+    @Override
+    public Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
+                          PauseDetector pauseDetector) {
+        Timer timer = new OracleCloudTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
+            this.oracleCloudConfig.step().toMillis(), false);
+        HistogramGauges.registerWithCommonFormat(timer, this);
+        return timer;
+    }
+
+    /**
+     * @param id The id that uniquely identifies the counter.
+     * @return
+     */
+    @Override
+    public Counter newCounter(Meter.Id id) {
+        return new OracleCloudCounter(id, clock, oracleCloudConfig.step().toMillis());
+    }
+
+    /**
+     * @param id                          The id that uniquely identifies the distribution summary.
+     * @param distributionStatisticConfig Configuration for published distribution
+     *                                    statistics.
+     * @param scale                       Multiply every recorded sample by this factor.
+     * @return
+     */
+    @Override
+    public DistributionSummary newDistributionSummary(Meter.Id id,
+                                                         DistributionStatisticConfig distributionStatisticConfig, double scale) {
+        DistributionSummary summary = new OracleCloudDistributionSummary(id, clock, distributionStatisticConfig, scale,
+            oracleCloudConfig.step().toMillis(), false);
+        HistogramGauges.registerWithCommonFormat(summary, this);
+        return summary;
+    }
+
+    @Override
+    protected List<MetricDataDetails> getMetricData() {
+        return getMeters().stream().flatMap(meter -> meter.match(
+            this::trackGauge,
+            this::trackRawData,
+            this::trackRawData,
+            this::trackRawData,
+            this::trackLongTaskTimer,
+            this::trackTimeGauge,
+            this::trackFunctionCounter,
+            this::trackFunctionTimer,
+            this::trackMeter)
+        ).collect(Collectors.toList());
+    }
+
+    Stream<MetricDataDetails> trackMeter(Meter meter) {
+        return StreamSupport.stream(meter.measure().spliterator(), false).map((ms) -> this.metricDataDetails(meter.getId().withTag(ms.getStatistic()), List.of(Datapoint.builder().timestamp(new Date()).value(ms.getValue()).build()))).filter(Objects::nonNull);
+    }
+
+    Stream<MetricDataDetails> trackGauge(Gauge gauge) {
+        Double value = gauge.value();
+        if (Double.isNaN(value)) {
+            return Stream.empty();
+        }
+        return Stream.of(metricDataDetails(gauge.getId(), List.of(Datapoint.builder().value(value).timestamp(new Date()).build())));
+    }
+
+    Stream<MetricDataDetails> trackTimeGauge(TimeGauge timeGauge) {
+        Double value = timeGauge.value(getBaseTimeUnit());
+        if (Double.isNaN(value)) {
+            return Stream.empty();
+        }
+        return Stream.of(metricDataDetails(timeGauge.getId(), List.of(Datapoint.builder().value(value).timestamp(new Date()).build())));
+    }
+
+    Stream<MetricDataDetails> trackFunctionCounter(FunctionCounter functionCounter) {
+        Double value = functionCounter.count();
+        if (Double.isNaN(value)) {
+            return Stream.empty();
+        }
+        return Stream.of(metricDataDetails(functionCounter.getId(), List.of(Datapoint.builder().value(value).timestamp(new Date()).build())));
+    }
+
+    Stream<MetricDataDetails> trackFunctionTimer(FunctionTimer functionTimer) {
+        return Stream.of(metricDataDetails(functionTimer.getId(), List.of(Datapoint.builder().value(functionTimer.totalTime(getBaseTimeUnit())).count(Double.valueOf(functionTimer.count()).intValue()).timestamp(new Date()).build())));
+    }
+
+    Stream<MetricDataDetails> trackLongTaskTimer(LongTaskTimer longTaskTimer) {
+        return Stream.of(metricDataDetails(longTaskTimer.getId(), List.of(Datapoint.builder().value(longTaskTimer.duration(getBaseTimeUnit())).count(Double.valueOf(longTaskTimer.activeTasks()).intValue()).timestamp(new Date()).build())));
+    }
+
+    Stream<MetricDataDetails> trackRawData(Meter meter) {
+        if (meter instanceof OracleCloudDatapointProducer datapointEntryProducer) {
+            return Stream.of(metricDataDetails(meter.getId(), datapointEntryProducer.produceDatapoints()));
+        }
+        logger.error("Metrics name: %s. Haven't publish metrics for class: %s".formatted(meter.getId().toString(), meter.getClass()));
+        return Stream.empty();
+    }
+
+    /**
+     * Generates {@link MetricDataDetails}.
+     *
+     * @param id meter id
+     * @param datapoints list of {@link Datapoint}
+     * @return {@link MetricDataDetails} ready to send to oracle cloud monitoring ingestion endpoint
+     */
+    MetricDataDetails metricDataDetails(Meter.Id id, List<Datapoint> datapoints) {
+        if (datapoints.isEmpty()) {
+            return null;
+        }
+        return MetricDataDetails.builder()
+            .compartmentId(oracleCloudConfig.compartmentId())
+            .name(getMetricName(id, null))
+            .namespace(oracleCloudConfig.namespace())
+            .resourceGroup(oracleCloudConfig.resourceGroup())
+            .metadata(oracleCloudConfig.description() && id.getDescription() != null
+                ? Collections.singletonMap("description", id.getDescription()) : null)
+            .datapoints(datapoints)
+            .dimensions(toDimensions(id.getConventionTags(config().namingConvention())))
+            .build();
+    }
+}

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -196,8 +196,8 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
      * @return {@link MetricDataDetails} stream with multiple entries of {@link Datapoint}
      */
     Stream<MetricDataDetails> trackRawData(Meter meter) {
-        if (meter instanceof OracleCloudDatapointProducer datapointEntryProducer) {
-            return Stream.of(metricDataDetails(meter.getId(), datapointEntryProducer.getDatapoints()));
+        if (meter instanceof OracleCloudDatapointProducer oracleCloudDatapointProducer) {
+            return Stream.of(metricDataDetails(meter.getId(), oracleCloudDatapointProducer.getDatapoints()));
         }
         logger.error("Metrics name: %s. Haven't publish metrics for class: %s".formatted(meter.getId().toString(), meter.getClass()));
         return Stream.empty();

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -236,7 +236,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
             .namespace(oracleCloudConfig.namespace())
             .resourceGroup(oracleCloudConfig.resourceGroup())
             .metadata(oracleCloudConfig.description() && id.getDescription() != null
-                ? Collections.singletonMap("description", id.getDescription()) : null)
+                ? Map.of("description", id.getDescription()) : null)
             .datapoints(datapoints)
             .dimensions(toDimensions(id.getConventionTags(config().namingConvention())))
             .build();

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
@@ -27,16 +27,16 @@ import java.util.concurrent.LinkedBlockingQueue;
  * DataPointProvider stores the {@link Datapoint}.
  */
 final class DataPointProvider {
-    private BlockingQueue<Datapoint> datapoints = new LinkedBlockingQueue<>();
+    private final BlockingQueue<Datapoint> datapoints = new LinkedBlockingQueue<>();
 
     /**
-     * Produces the list of datapoints that will be sent. It will also preform cleanup
+     * Produces the list of datapoints that will be sent. It will also perform cleanup
      * of the internal array
      *
      * @return list of {@link Datapoint}
      */
     List<Datapoint> produceDatapoints() {
-        ArrayList<Datapoint> datapointsToReturn = new ArrayList<>();
+        List<Datapoint> datapointsToReturn = new ArrayList<>();
         datapoints.drainTo(datapointsToReturn);
         return datapointsToReturn;
     }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.monitoring.primitives;
+
+import com.oracle.bmc.monitoring.model.Datapoint;
+import io.micrometer.core.instrument.step.StepCounter;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * DataPointProvider stores the {@link Datapoint}.
+ */
+final class DataPointProvider {
+
+    private List<Datapoint> datapoints = new ArrayList<>();
+
+    /**
+     * Produces the list of datapoints that will be sent. It will also preform cleanup
+     * of the internal array
+     *
+     * @return list of {@link Datapoint}
+     */
+    public synchronized List<Datapoint> produceDatapoints() {
+        ArrayList<Datapoint> datapointsToReturn = new ArrayList<>(datapoints);
+        datapoints = new ArrayList<>();
+        return datapointsToReturn;
+    }
+
+    /**
+     * Creates {@link Datapoint} based on value.
+     * @param value of the datapoint
+     */
+    void createDataPoint(Double value) {
+        if (Double.isNaN(value)) {
+            return;
+        }
+        synchronized (this) {
+            datapoints.add(Datapoint.builder().timestamp(new Date()).value(value).build());
+        }
+    }
+
+    /**
+     * Creates {@link Datapoint} based on value.
+     * @param value of the datapoint
+     * @param count of the datapoint
+     */
+    synchronized void createDataPoint(Double value, Integer count) {
+        datapoints.add(Datapoint.builder().timestamp(new Date()).value(value).count(count).build());
+    }
+}

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.monitoring.primitives;
+
+import com.oracle.bmc.monitoring.model.Datapoint;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.step.StepCounter;
+import io.micronaut.core.annotation.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OracleCloudCounter is {@link StepCounter} that tracks list of raw {@link Datapoint}.
+ */
+@Internal
+public final class OracleCloudCounter extends StepCounter implements OracleCloudDatapointProducer {
+
+    private List<Datapoint> dataPointEntries = new ArrayList<>();
+
+    public OracleCloudCounter(Id id, Clock clock, long stepMillis) {
+        super(id, clock, stepMillis);
+    }
+
+    @Override
+    public void increment(double amount) {
+        super.increment(amount);
+        createDataPoint(amount);
+    }
+
+    @Override
+    public void cleanDatapoints() {
+        dataPointEntries = new ArrayList<>();
+    }
+
+    @Override
+    public List<Datapoint> getDatapoints() {
+        return dataPointEntries;
+    }
+}

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
@@ -20,7 +20,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.step.StepCounter;
 import io.micronaut.core.annotation.Internal;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -28,8 +27,7 @@ import java.util.List;
  */
 @Internal
 public final class OracleCloudCounter extends StepCounter implements OracleCloudDatapointProducer {
-
-    private List<Datapoint> dataPointEntries = new ArrayList<>();
+    private final DataPointProvider dataPointProvider = new DataPointProvider();
 
     public OracleCloudCounter(Id id, Clock clock, long stepMillis) {
         super(id, clock, stepMillis);
@@ -38,16 +36,11 @@ public final class OracleCloudCounter extends StepCounter implements OracleCloud
     @Override
     public void increment(double amount) {
         super.increment(amount);
-        createDataPoint(amount);
-    }
-
-    @Override
-    public void cleanDatapoints() {
-        dataPointEntries = new ArrayList<>();
+        dataPointProvider.createDataPoint(amount);
     }
 
     @Override
     public List<Datapoint> getDatapoints() {
-        return dataPointEntries;
+        return dataPointProvider.produceDatapoints();
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
@@ -23,7 +23,7 @@ import io.micronaut.core.annotation.Internal;
 import java.util.List;
 
 /**
- * OracleCloudCounter is {@link StepCounter} that tracks list of raw {@link Datapoint}.
+ * A {@link StepCounter} that tracks list of raw {@link Datapoint}.
  */
 @Internal
 public final class OracleCloudCounter extends StepCounter implements OracleCloudDatapointProducer {

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDatapointProducer.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDatapointProducer.java
@@ -18,65 +18,18 @@ package io.micronaut.oraclecloud.monitoring.primitives;
 import com.oracle.bmc.monitoring.model.Datapoint;
 import io.micrometer.core.instrument.Meter;
 
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 /**
- * A Meter that collects and produces raw {@link Datapoint}.
+ * A Meter that collects raw {@link Datapoint}.
  */
 public interface OracleCloudDatapointProducer extends Meter {
 
     /**
-     * Cleans the datapoints list.
-     */
-    void cleanDatapoints();
-
-    /**
-     * Only for internal usages. Returns the current datapoint list.
+     * Returns list of datapoints that will be sent.
      *
      * @return list of {@link Datapoint}
      */
     List<Datapoint> getDatapoints();
-
-    /**
-     * Produces the list of datapoints that will be sent. It will also preform cleanup
-     * of the internal array
-     *
-     * @return list of {@link Datapoint}
-     */
-    default List<Datapoint> produceDatapoints() {
-        synchronized (this) {
-            ArrayList<Datapoint> datapointsToReturn = new ArrayList<>(getDatapoints());
-            cleanDatapoints();
-            return datapointsToReturn;
-        }
-    }
-
-    /**
-     * Creates {@link Datapoint} based on value.
-     * @param value of the datapoint
-     */
-    default void createDataPoint(Double value) {
-        if (Double.isNaN(value)) {
-            return;
-        }
-        synchronized (this) {
-            getDatapoints().add(
-                Datapoint.builder().timestamp(new Date()).value(value).build()
-            );
-        }
-    }
-
-    /**
-     * Creates {@link Datapoint} based on value.
-     * @param value of the datapoint
-     * @param count of the datapoint
-     */
-    default void createDataPoint(Double value, Integer count) {
-        synchronized (this) {
-            getDatapoints().add(Datapoint.builder().timestamp(new Date()).value(value).count(count).build());
-        }
-    }
 
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDatapointProducer.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDatapointProducer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.monitoring.primitives;
+
+import com.oracle.bmc.monitoring.model.Datapoint;
+import io.micrometer.core.instrument.Meter;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A Meter that collects and produces raw {@link Datapoint}.
+ */
+public interface OracleCloudDatapointProducer extends Meter {
+
+    /**
+     * Cleans the datapoints list.
+     */
+    void cleanDatapoints();
+
+    /**
+     * Only for internal usages. Returns the current datapoint list.
+     *
+     * @return list of {@link Datapoint}
+     */
+    List<Datapoint> getDatapoints();
+
+    /**
+     * Produces the list of datapoints that will be sent. It will also preform cleanup
+     * of the internal array
+     *
+     * @return list of {@link Datapoint}
+     */
+    default List<Datapoint> produceDatapoints() {
+        synchronized (this) {
+            ArrayList<Datapoint> datapointsToReturn = new ArrayList<>(getDatapoints());
+            cleanDatapoints();
+            return datapointsToReturn;
+        }
+    }
+
+    /**
+     * Creates {@link Datapoint} based on value.
+     * @param value of the datapoint
+     */
+    default void createDataPoint(Double value) {
+        if (Double.isNaN(value)) {
+            return;
+        }
+        synchronized (this) {
+            getDatapoints().add(
+                Datapoint.builder().timestamp(new Date()).value(value).build()
+            );
+        }
+    }
+
+    /**
+     * Creates {@link Datapoint} based on value.
+     * @param value of the datapoint
+     * @param count of the datapoint
+     */
+    default void createDataPoint(Double value, Integer count) {
+        synchronized (this) {
+            getDatapoints().add(Datapoint.builder().timestamp(new Date()).value(value).count(count).build());
+        }
+    }
+
+}

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
@@ -20,7 +20,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.step.StepDistributionSummary;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ import java.util.List;
  */
 public class OracleCloudDistributionSummary extends StepDistributionSummary implements OracleCloudDatapointProducer {
 
-    private List<Datapoint> dataPointEntries = new ArrayList<>();
+    private final DataPointProvider dataPointProvider = new DataPointProvider();
 
     public OracleCloudDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles);
@@ -37,16 +36,11 @@ public class OracleCloudDistributionSummary extends StepDistributionSummary impl
     @Override
     protected void recordNonNegative(double amount) {
         super.recordNonNegative(amount);
-        createDataPoint(amount, 1);
-    }
-
-    @Override
-    public void cleanDatapoints() {
-        dataPointEntries = new ArrayList<>();
+        dataPointProvider.createDataPoint(amount, 1);
     }
 
     @Override
     public List<Datapoint> getDatapoints() {
-        return dataPointEntries;
+        return dataPointProvider.produceDatapoints();
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.monitoring.primitives;
+
+import com.oracle.bmc.monitoring.model.Datapoint;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.step.StepDistributionSummary;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OracleCloudDistributionSummary is {@link StepDistributionSummary} that tracks list of raw {@link Datapoint}.
+ */
+public class OracleCloudDistributionSummary extends StepDistributionSummary implements OracleCloudDatapointProducer {
+
+    private List<Datapoint> dataPointEntries = new ArrayList<>();
+
+    public OracleCloudDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles) {
+        super(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles);
+    }
+
+    @Override
+    protected void recordNonNegative(double amount) {
+        super.recordNonNegative(amount);
+        createDataPoint(amount, 1);
+    }
+
+    @Override
+    public void cleanDatapoints() {
+        dataPointEntries = new ArrayList<>();
+    }
+
+    @Override
+    public List<Datapoint> getDatapoints() {
+        return dataPointEntries;
+    }
+}

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
@@ -23,7 +23,7 @@ import io.micrometer.core.instrument.step.StepDistributionSummary;
 import java.util.List;
 
 /**
- * OracleCloudDistributionSummary is {@link StepDistributionSummary} that tracks list of raw {@link Datapoint}.
+ * A {@link StepDistributionSummary} that tracks list of raw {@link Datapoint}.
  */
 public class OracleCloudDistributionSummary extends StepDistributionSummary implements OracleCloudDatapointProducer {
 

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
@@ -22,7 +22,6 @@ import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.step.StepTimer;
 import io.micrometer.core.instrument.util.TimeUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -31,8 +30,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class OracleCloudTimer extends StepTimer implements OracleCloudDatapointProducer {
     private final TimeUnit timeUnit;
-
-    private List<Datapoint> dataPointEntries = new ArrayList<>();
+    private final DataPointProvider dataPointProvider = new DataPointProvider();
 
     public OracleCloudTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, supportsAggregablePercentiles);
@@ -43,16 +41,11 @@ public class OracleCloudTimer extends StepTimer implements OracleCloudDatapointP
     protected void recordNonNegative(final long amount, final TimeUnit unit) {
         super.recordNonNegative(amount, unit);
         final long nanoAmount = (long) TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS);
-        createDataPoint(TimeUtils.nanosToUnit(nanoAmount, timeUnit));
-    }
-
-    @Override
-    public void cleanDatapoints() {
-        dataPointEntries = new ArrayList<>();
+        dataPointProvider.createDataPoint(TimeUtils.nanosToUnit(nanoAmount, timeUnit));
     }
 
     @Override
     public List<Datapoint> getDatapoints() {
-        return dataPointEntries;
+        return dataPointProvider.produceDatapoints();
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * OracleCloudTimer is {@link StepTimer} that tracks list of raw {@link Datapoint}.
+ * A {@link StepTimer} that tracks list of raw {@link Datapoint}.
  */
 public class OracleCloudTimer extends StepTimer implements OracleCloudDatapointProducer {
     private final TimeUnit timeUnit;

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.monitoring.primitives;
+
+import com.oracle.bmc.monitoring.model.Datapoint;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.step.StepTimer;
+import io.micrometer.core.instrument.util.TimeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * OracleCloudTimer is {@link StepTimer} that tracks list of raw {@link Datapoint}.
+ */
+public class OracleCloudTimer extends StepTimer implements OracleCloudDatapointProducer {
+    private final TimeUnit timeUnit;
+
+    private List<Datapoint> dataPointEntries = new ArrayList<>();
+
+    public OracleCloudTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles) {
+        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, supportsAggregablePercentiles);
+        this.timeUnit = baseTimeUnit;
+    }
+
+    @Override
+    protected void recordNonNegative(final long amount, final TimeUnit unit) {
+        super.recordNonNegative(amount, unit);
+        final long nanoAmount = (long) TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS);
+        createDataPoint(TimeUtils.nanosToUnit(nanoAmount, timeUnit));
+    }
+
+    @Override
+    public void cleanDatapoints() {
+        dataPointEntries = new ArrayList<>();
+    }
+
+    @Override
+    public List<Datapoint> getDatapoints() {
+        return dataPointEntries;
+    }
+}

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactoryTest.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactoryTest.groovy
@@ -6,6 +6,7 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudMeterRegistry
+import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudRawMeterRegistry
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Specification
 
@@ -43,5 +44,17 @@ class OracleCloudMeterRegistryFactoryTest extends Specification {
 
         expect:
         context.containsBean(OracleCloudMeterRegistry)
+    }
+
+    def "test raw metrics meter registry"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "micronaut.metrics.export.oraclecloud.namespace"      : "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.applicationName": "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.raw.enabled"    : "true",
+        ], Environment.ORACLE_CLOUD)
+
+        expect:
+        context.containsBean(OracleCloudRawMeterRegistry)
     }
 }

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
@@ -1,0 +1,207 @@
+package io.micronaut.oraclecloud.monitoring.micrometer
+
+import com.oracle.bmc.monitoring.MonitoringClient
+import com.oracle.bmc.monitoring.model.Datapoint
+import io.micrometer.core.instrument.*
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.stream.Collectors
+
+class OracleCloudMeterRawRegistrySpec extends Specification {
+
+    @Shared
+    private MockClock mockClock = new MockClock()
+
+    @Shared
+    private OracleCloudConfig oracleCloudConfig = new OracleCloudConfig() {
+
+        @Override
+        String compartmentId() {
+            return "compartmentId"
+        }
+
+        @Override
+        String namespace() {
+            return "namespace"
+        }
+
+        @Override
+        String applicationName() {
+            return "appName"
+        }
+
+        @Override
+        String get(String key) {
+            return null
+        }
+    }
+
+    @Shared
+    private MonitoringClient monitoringClient = Mock(MonitoringClient)
+
+    @AutoCleanup
+    @Shared
+    private OracleCloudRawMeterRegistry cloudMeterRegistry = new OracleCloudRawMeterRegistry(oracleCloudConfig, mockClock, monitoringClient)
+
+    def cleanup() {
+        cloudMeterRegistry.clear()
+    }
+
+    def "test it generates name with suffix"() {
+        given:
+        Meter.Id id = new Meter.Id("name", Tags.empty(), null, null, Meter.Type.COUNTER)
+
+        expect:
+        cloudMeterRegistry.getMetricName(id, null) == "name"
+        cloudMeterRegistry.getMetricName(id, "suffix") == "name_suffix"
+    }
+
+    def "test it validates dimension keys"() {
+        given:
+        def tags = Tags.of("valid", "tag").and("", "missing key").and("missing value", "")
+
+        when:
+        def dimensions = cloudMeterRegistry.toDimensions(tags.asList())
+
+        then:
+        dimensions
+        dimensions.size() == 1
+        dimensions.containsKey("valid")
+    }
+
+    def "test metric with NaN is not added"() {
+        given:
+        cloudMeterRegistry.gauge("gauge", Double.NaN)
+
+        expect:
+        cloudMeterRegistry.metricData.size() == 0
+    }
+
+    def "test it adds metric description to metadata"(){
+        given:
+        Meter.Id id = new Meter.Id("name", Tags.empty(), null, "description in metadata", Meter.Type.COUNTER)
+
+        when:
+        def details =  cloudMeterRegistry.metricDataDetails(id, List.of(Datapoint.builder().value(1d).timestamp(new Date()).build()))
+
+        then:
+        details.metadata
+        details.metadata.containsKey("description")
+        details.metadata.get("description") == "description in metadata"
+    }
+
+    def "test it can track gauge"() {
+        given:
+        cloudMeterRegistry.gauge("gauge", 1d)
+
+        when:
+        def data = cloudMeterRegistry.getMetricData()
+
+        then:
+        data
+        data.size() == 1
+        data.first().datapoints
+        data.first().datapoints.size() == 1
+        data.first().name == "gauge"
+        data.first().datapoints.first().value == 1d
+    }
+
+    def "test it can track counter"() {
+        given:
+        def counter = cloudMeterRegistry.counter("counter")
+        counter.increment()
+        counter.increment()
+
+        when:
+        mockClock.add(oracleCloudConfig.step())
+        def data = cloudMeterRegistry.trackRawData(counter).findFirst().get()
+
+        then:
+        data.name == "counter"
+        data.datapoints
+        data.datapoints.size() == 2
+        data.datapoints[0].value == 1
+        data.datapoints[1].value == 1
+    }
+
+    def "test it can track timer"() {
+        given:
+        def timer = cloudMeterRegistry.timer("timer")
+        timer.record(Duration.ofSeconds(1))
+        timer.record(Duration.ofSeconds(2))
+
+        when:
+        mockClock.add(oracleCloudConfig.step())
+        def data = cloudMeterRegistry.trackRawData(timer).collect(Collectors.toList())
+
+        then:
+        data.size() == 1
+        data[0].name == "timer"
+        data[0].datapoints.size() == 2
+        data[0].datapoints[0].value == 1000
+        data[0].datapoints[1].value == 2000
+    }
+
+    def "test it can track distribution summary"() {
+        given:
+        DistributionSummary summary = DistributionSummary
+                .builder("distributionSummary")
+                .scale(100)
+                .register(cloudMeterRegistry);
+        summary.record(10)
+        summary.record(12)
+        summary.record(14)
+        mockClock.add(oracleCloudConfig.step())
+
+        when:
+        def data = cloudMeterRegistry.trackRawData(summary).collect(Collectors.toList())
+
+
+        then:
+        data.size() == 1
+        data[0].name == "distributionSummary"
+        data[0].datapoints.size() == 3
+        data[0].datapoints[0].value == 10 * 100
+        data[0].datapoints[1].value == 12 * 100
+        data[0].datapoints[2].value == 14 * 100
+    }
+
+    def "test it can track function counter"(){
+        given:
+        def functionCounter = FunctionCounter.builder("functionCounter", 5d, x -> (double) x)
+                .register(cloudMeterRegistry)
+        mockClock.add(oracleCloudConfig.step())
+
+        when:
+        def data = cloudMeterRegistry.trackFunctionCounter(functionCounter).collect(Collectors.toList())
+
+        then:
+        data
+        data.size() == 1
+        data[0].name == "functionCounter"
+        data[0].datapoints.first().value == 5
+    }
+
+    def "test it can track function timer"() {
+        given:
+        def functionTimer = FunctionTimer.builder("functionTimer", 1d,
+                x -> (long) x,
+                x -> (double) x,
+                cloudMeterRegistry.getBaseTimeUnit())
+                .register(cloudMeterRegistry)
+        mockClock.add(oracleCloudConfig.step());
+
+        when:
+        def data = cloudMeterRegistry.trackFunctionTimer(functionTimer).collect(Collectors.toList())
+
+        then:
+        data
+        data.size() == 1
+        data[0].name == "functionTimer"
+        data[0].datapoints.first().value == 1
+        data[0].datapoints.first().count == 1
+    }
+}


### PR DESCRIPTION
This PR adds a new OracleCloud Meter registry that will provide more accuracy to the metrics. The old OracleCloud meter registry aggregates all data and publishes it to OracleCloud. Because of aggregation of the metrics the server side doesn't make any sense for aggregation. 

Raw metrics are available for: 
- `Counter`
- `Timer`
- `DistributionSummary`

Other primitives like `Gauge`, `FunctionCounter`, `FunctionTimer` are only observed once before publishing metrics, so no raw data is available. 


