### PR TITLE
Fixes raw metrics issue if oraclecloud.enabled is false

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -80,6 +80,10 @@ public class OracleCloudMeterRegistryFactory {
             return tenancyIdProvider.getTenancyId();
         });
 
+        if ("true".equals(exportConfigurationProperties.getExport().getProperty(OracleCloudConfig.PREFIX + ".raw.enabled"))) {
+            exportConfigurationProperties.getExport().put(OracleCloudConfig.PREFIX + ".enabled", "true");
+        }
+
         Properties exportConfig = exportConfigurationProperties.getExport();
         return exportConfig::getProperty;
     }


### PR DESCRIPTION
Fixes metrics issue when `oraclecloud.enabled` is `false` and `oraclecloud.raw.enabled` is `true`. 

- Sets `oraclecloud.enabled` to `true` if `oraclecloud.raw.enabled` is true.

This is required that `PushMeterRegistry` to publish metrics.