### PR TITLE
Improve OCI Config File support

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-bom.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-bom.gradle
@@ -9,7 +9,7 @@ static Collection<String> parseOciBomArtifacts(String version) {
 }
 
 static Collection<File> parseOciSdkModules() {
-    var modules = new File("checkouts/oci-java-sdk").listFiles().findAll {it.name.startsWith("bmc-")}
+    var modules = new File("target/checkouts/oci-java-sdk").listFiles().findAll {it.name.startsWith("bmc-")}
     var secondLevelModules = modules.collectMany {
         it.listFiles().findAll{ it.name.startsWith("bmc-") }
     }
@@ -37,7 +37,7 @@ if (!extraPropertiesExtension.has('ociArtifacts')) {
     def ociArtifacts = parseOciBomArtifacts(ociVersion)
             .stream().filter(artifact -> artifact != "oci-java-sdk-shaded-full").toList()
 
-    String ociProjectVersion = new XmlSlurper().parse("checkouts/oci-java-sdk/bmc-bom/pom.xml").version.text()
+    String ociProjectVersion = new XmlSlurper().parse("target/checkouts/oci-java-sdk/bmc-bom/pom.xml").version.text()
     def ociProjectArtifacts = parseOciBomArtifacts(ociProjectVersion)
 
     if (ociVersion != ociProjectVersion) {

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigCondition.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigCondition.java
@@ -32,7 +32,7 @@ import static io.micronaut.oraclecloud.core.OracleCloudCoreFactory.ORACLE_CLOUD_
  * @since 1.0.0
  */
 @BootstrapContextCompatible
-class OracleCloudConfigCondition implements Condition {
+public class OracleCloudConfigCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context) {
         String configPath = context.getProperty(ORACLE_CLOUD_CONFIG_PATH, Argument.STRING)

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigFileConfigurationProperties.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigFileConfigurationProperties.java
@@ -1,0 +1,28 @@
+package io.micronaut.oraclecloud.core;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.Toggleable;
+
+import static io.micronaut.oraclecloud.core.OracleCloudConfigFileConfigurationProperties.PREFIX;
+
+/**
+ * Configuration properties for the local OCI config file (eg: {@code $USE_HOME/.oci/config}).
+ *
+ * @param profile The profile to use.
+ * @param configPath A custom path for the OCI configuration file.
+ * @param enabled Whether to enable or disable using the OCI configuration file.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.6.0
+ */
+@ConfigurationProperties(PREFIX)
+public record OracleCloudConfigFileConfigurationProperties(@Nullable String profile, @Nullable String configPath, @Nullable Boolean enabled) implements Toggleable {
+
+    public static final String PREFIX = OracleCloudCoreFactory.ORACLE_CLOUD + ".config";
+
+    @Override
+    public boolean isEnabled() {
+        return enabled != null && enabled;
+    }
+}

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigFileConfigurationProperties.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudConfigFileConfigurationProperties.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.oraclecloud.core;
 
 import io.micronaut.context.annotation.ConfigurationProperties;

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
@@ -29,7 +29,6 @@ import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.context.exceptions.DisabledBeanException;

--- a/oraclecloud-common/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudConfigFileConfigurationPropertiesSpec.groovy
+++ b/oraclecloud-common/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudConfigFileConfigurationPropertiesSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.discovery.cloud
+
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.oraclecloud.core.OracleCloudConfigFileConfigurationProperties
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+
+class OracleCloudConfigFileConfigurationPropertiesSpec extends Specification {
+
+    @Shared
+    @TempDir
+    Path testPath
+
+    @Shared
+    File ociConfig
+
+    void setupSpec() {
+        ociConfig = testPath.resolve("config").toFile()
+        ociConfig.text = '''
+[DEFAULT]
+user=ocid1.user.oc1..aaaaaaaaxxxx
+fingerprint=xx:xx:xx:xx:xx:xx:xx
+key_file=${testPath}/oci_api_key.pem
+tenancy=ocid1.tenancy.oc1..aaaaaaaaxxxx
+region=us-ashburn-1
+pass_phrase=xxxxx'''
+
+    }
+
+    void 'it is enabled by default'() {
+        given:
+        def ctx = ApplicationContext.run([
+                (OracleCloudConfigFileConfigurationProperties.PREFIX + ".config-path"): ociConfig.absolutePath
+        ], Environment.ORACLE_CLOUD)
+
+        expect:
+        ctx.containsBean(ConfigFileAuthenticationDetailsProvider)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void 'it can be disabled even if config file exists'() {
+        given:
+        def ctx = ApplicationContext.run([
+                (OracleCloudConfigFileConfigurationProperties.PREFIX + ".config-path"): ociConfig.absolutePath,
+                (OracleCloudConfigFileConfigurationProperties.PREFIX + ".enabled"): false
+        ], Environment.ORACLE_CLOUD)
+
+        expect:
+        !ctx.containsBean(ConfigFileAuthenticationDetailsProvider)
+
+        cleanup:
+        ctx.close()
+
+    }
+}

--- a/oraclecloud-common/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudV2MetadataResolverSpec.groovy
+++ b/oraclecloud-common/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudV2MetadataResolverSpec.groovy
@@ -45,6 +45,9 @@ class OracleCloudV2MetadataResolverSpec extends Specification {
         then:
         assertThatMetadataIsCorrect(metadata)
 
+        cleanup:
+        ctx.close()
+        server.stop()
     }
 
     @Controller("/opc/v2")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,6 +83,8 @@ configure<io.micronaut.build.MicronautBuildSettingsExtension> {
 val libs = Toml.parse(File(rootProject.projectDir.absoluteFile, "gradle/libs.versions.toml").toPath())!!
 
 gitRepositories {
+    // Checkout in a directory that is ignored by the sync'ed .gitignore
+    checkoutsDirectory.set(file("target/checkouts"))
     include("oci-java-sdk") {
         uri.set("https://github.com/oracle/oci-java-sdk.git")
         autoInclude.set(false)

--- a/src/main/docs/guide/authentication.adoc
+++ b/src/main/docs/guide/authentication.adoc
@@ -10,13 +10,8 @@ The following authentication providers are supported in this module:
 
 {ocidocs}/com/oracle/bmc/auth/ConfigFileAuthenticationDetailsProvider.html[ConfigFileAuthenticationDetailsProvider] uses a config file located at `$USER_HOME/.oci/config`. Specify a profile or config file path within the config file via your `application` configuration file:
 
-[configuration]
-----
-oci:
-  config:
-    profile: DEFAULT
-    path: /custom/path/to/config/file
-----
+include::{includedir}configurationProperties/io.micronaut.oraclecloud.core.OracleCloudConfigFileConfigurationProperties.adoc[]
+
 
 NOTE: In the Oracle Java SDK the environment variable `OCI_CONFIG_FILE` doesn't take precedence over the `~/.oci/config` if the file exists. Assign the `OCI_CONFIG_FILE` to `oci.config.path`. To change the order: `oci.config.path: ${OCI_CONFIG_FILE}`
 


### PR DESCRIPTION
This PR:
* Makes `OracleCloudConfigCondition` public (fixes #781).
* Adds an `enabled` flag to toggle the use of `~/.oci/config` (previously, if the file existed, would be used no matter what).
* Introduces a new configuration class so that properties are documented:

![image](https://github.com/micronaut-projects/micronaut-oracle-cloud/assets/153880/6cd546f3-4f78-47e6-90db-9eef66fd8ef7)
