### PR TITLE
build: managed ucp and observability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.6.2-SNAPSHOT
+projectVersion=3.7.0-SNAPSHOT
 projectGroup=io.micronaut.oraclecloud
 
 title=Micronaut Oracle Cloud

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,11 @@ micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-
 micronaut-discovery-client = { module = "io.micronaut.discovery:micronaut-discovery-client-bom", version.ref = "micronaut-discovery-client" }
 micronaut-test = { module = "io.micronaut.test:micronaut-test-bom", version.ref = "micronaut-test" }
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
+
 managed-oracle-jdbc = { module = 'com.oracle.database.jdbc:ojdbc11', version.ref = 'managed-ojdbc'  }
+managed-oracle-jdbc-ucp = { module = 'com.oracle.database.jdbc:ucp', version.ref = 'managed-ojdbc'  }
+managed-oracle-observability-dms = { module = 'com.oracle.database.observability:dms', version.ref = 'managed-ojdbc'  }
+managed-oracle-observability-ojdbc11dms = { module = 'com.oracle.database.observability:ojdbc11dms', version.ref = 'managed-ojdbc'  }
 
 fn-api = { module = 'com.fnproject.fn:api', version.ref = 'fn' }
 fn-runtime = { module = 'com.fnproject.fn:runtime', version.ref = 'fn' }


### PR DESCRIPTION
Expose oracle-jdbc-ucp and oracle-observability so that we can consume it from Micronaut SQL.

closes #820
follow-on to #804