### PR TITLE
fix circular dependency issue

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -27,6 +27,7 @@ import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudConfig;
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudMeterRegistry;
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudRawMeterRegistry;
 import io.micronaut.runtime.ApplicationConfiguration;
+import jakarta.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,8 +104,8 @@ public class OracleCloudMeterRegistryFactory {
     @Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
     @Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_RAW_METRICS_ENABLED, notEquals = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
     OracleCloudMeterRegistry oracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig,
-                                                      MonitoringIngestionClient monitoringIngestionClient) {
-        return new OracleCloudMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClient.getDelegate());
+                                                      Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
+        return new OracleCloudMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
     }
 
     /**
@@ -120,7 +121,7 @@ public class OracleCloudMeterRegistryFactory {
     @Bean(preDestroy = "close")
     @Requires(property = MeterRegistryFactory.MICRONAUT_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
     @Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_RAW_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.FALSE)
-    OracleCloudRawMeterRegistry oracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig, MonitoringIngestionClient monitoringIngestionClient) {
-        return new OracleCloudRawMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClient.getDelegate());
+    OracleCloudRawMeterRegistry oracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
+        return new OracleCloudRawMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistry.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.oraclecloud.monitoring.micrometer;
 
-import com.oracle.bmc.monitoring.MonitoringClient;
 import com.oracle.bmc.monitoring.model.Datapoint;
 import com.oracle.bmc.monitoring.model.MetricDataDetails;
 import io.micrometer.core.instrument.Clock;
@@ -31,6 +30,8 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.lang.Nullable;
+import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient;
+import jakarta.inject.Provider;
 
 import java.util.Collections;
 import java.util.Date;
@@ -52,15 +53,15 @@ public class OracleCloudMeterRegistry extends AbstractOracleCloudMeterRegistry {
 
     public OracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig,
                                     Clock clock,
-                                    MonitoringClient monitoringClient) {
-        this(oracleCloudConfig, clock, monitoringClient, new NamedThreadFactory("oraclecloud-metrics-publisher"));
+                                    Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
+        this(oracleCloudConfig, clock, monitoringIngestionClientProvider, new NamedThreadFactory("oraclecloud-metrics-publisher"));
     }
 
     public OracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig,
                                     Clock clock,
-                                    MonitoringClient monitoringClient,
+                                    Provider<MonitoringIngestionClient> monitoringIngestionClientProvider,
                                     ThreadFactory threadFactory) {
-        super(oracleCloudConfig, clock, monitoringClient, threadFactory);
+        super(oracleCloudConfig, clock, monitoringIngestionClientProvider, threadFactory);
     }
 
     /**
@@ -78,7 +79,7 @@ public class OracleCloudMeterRegistry extends AbstractOracleCloudMeterRegistry {
                 this::trackFunctionCounter,
                 this::trackFunctionTimer,
                 this::trackMeter)
-        ).collect(Collectors.toList());
+        ).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     /**

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.oraclecloud.monitoring.micrometer;
 
-import com.oracle.bmc.monitoring.MonitoringClient;
 import com.oracle.bmc.monitoring.model.Datapoint;
 import com.oracle.bmc.monitoring.model.MetricDataDetails;
 import io.micrometer.core.instrument.Clock;
@@ -34,10 +33,12 @@ import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.lang.Nullable;
+import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient;
 import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudDatapointProducer;
 import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudCounter;
 import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudDistributionSummary;
 import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudTimer;
+import jakarta.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,16 +62,16 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
     private final Logger logger = LoggerFactory.getLogger(OracleCloudRawMeterRegistry.class);
 
     public OracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig,
-                                    Clock clock,
-                                    MonitoringClient monitoringClient) {
-        this(oracleCloudConfig, clock, monitoringClient, new NamedThreadFactory("oraclecloud-metrics-publisher"));
+                                       Clock clock,
+                                       Provider<MonitoringIngestionClient> monitoringIngestionClientProvider
+                                       ) {
+        this(oracleCloudConfig, clock, monitoringIngestionClientProvider, new NamedThreadFactory("oraclecloud-metrics-publisher"));
     }
 
     public OracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig,
-                                    Clock clock,
-                                    MonitoringClient monitoringClient,
-                                    ThreadFactory threadFactory) {
-        super(oracleCloudConfig, clock, monitoringClient, threadFactory);
+                                       Clock clock, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider,
+                                       ThreadFactory threadFactory) {
+        super(oracleCloudConfig, clock, monitoringIngestionClientProvider, threadFactory);
 
     }
 
@@ -128,7 +129,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
             this::trackFunctionCounter,
             this::trackFunctionTimer,
             this::trackMeter)
-        ).collect(Collectors.toList());
+        ).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     /**

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
@@ -3,6 +3,8 @@ package io.micronaut.oraclecloud.monitoring.micrometer
 import com.oracle.bmc.monitoring.MonitoringClient
 import com.oracle.bmc.monitoring.model.Datapoint
 import io.micrometer.core.instrument.*
+import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient
+import jakarta.inject.Provider
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -40,11 +42,16 @@ class OracleCloudMeterRawRegistrySpec extends Specification {
     }
 
     @Shared
-    private MonitoringClient monitoringClient = Mock(MonitoringClient)
+    private MonitoringIngestionClient monitoringClient = Mock(MonitoringIngestionClient)
 
     @AutoCleanup
     @Shared
-    private OracleCloudRawMeterRegistry cloudMeterRegistry = new OracleCloudRawMeterRegistry(oracleCloudConfig, mockClock, monitoringClient)
+    private OracleCloudRawMeterRegistry cloudMeterRegistry = new OracleCloudRawMeterRegistry(oracleCloudConfig, mockClock, new Provider<MonitoringIngestionClient>() {
+        @Override
+        MonitoringIngestionClient get() {
+            monitoringClient
+        }
+    })
 
     def cleanup() {
         cloudMeterRegistry.clear()

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistrySpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistrySpec.groovy
@@ -7,6 +7,8 @@ import io.micrometer.core.instrument.FunctionTimer
 import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.MockClock
 import io.micrometer.core.instrument.Tags
+import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient
+import jakarta.inject.Provider
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -43,11 +45,16 @@ class OracleCloudMeterRegistrySpec extends Specification {
     }
 
     @Shared
-    private MonitoringClient monitoringClient = Mock(MonitoringClient)
+    private MonitoringIngestionClient monitoringClient = Mock(MonitoringIngestionClient)
 
     @AutoCleanup
     @Shared
-    private OracleCloudMeterRegistry cloudMeterRegistry = new OracleCloudMeterRegistry(oracleCloudConfig, mockClock, monitoringClient)
+    private OracleCloudMeterRegistry cloudMeterRegistry = new OracleCloudMeterRegistry(oracleCloudConfig, mockClock, new Provider<MonitoringIngestionClient>() {
+        @Override
+        MonitoringIngestionClient get() {
+            monitoringClient
+        }
+    })
 
     def cleanup() {
         cloudMeterRegistry.clear()


### PR DESCRIPTION
- `OracleCloudRawMeterRegistry` and `OracleCloudMeterRegistry` has now `Provider<MonitoringIngestionClient> monitoringIngestionClientProvider` instead of `MonitoringClient monitoringClient`. 

- Removes null entries from publishing metrics

This is a breaking change.