### PR TITLE
Allow retry on closed channel

### DIFF
--- a/.github/workflows/graalvm-oci.yml
+++ b/.github/workflows/graalvm-oci.yml
@@ -26,7 +26,7 @@ jobs:
           oci-private-key-passphrase: ${{ secrets.OCI_PASSPHRASE }}
           oci-private-key-fingerprint: ${{ secrets.OCI_FINGERPRINT }}
       - name: Start runner
-        uses: micronaut-projects/github-actions/start-oracle-cloud-runners@master
+        uses: micronaut-projects/github-actions/start-oracle-cloud-runners@update-oci-start-runners
         id: start-runner
         with:
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -34,7 +34,6 @@ jobs:
           oci-subnet-ocid: ${{ secrets.OCI_SUBNET }}
           oci-av-domain: ${{ secrets.OCI_AV_DOMAIN }}
           oci-image-ocid: ${{ secrets.OCI_RUNNER_IMAGE }}
-          oci-image-shape: "VM.Standard.E4.4"
           runners-count: '1'
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'

--- a/.github/workflows/graalvm-oci.yml
+++ b/.github/workflows/graalvm-oci.yml
@@ -34,6 +34,7 @@ jobs:
           oci-subnet-ocid: ${{ secrets.OCI_SUBNET }}
           oci-av-domain: ${{ secrets.OCI_AV_DOMAIN }}
           oci-image-ocid: ${{ secrets.OCI_RUNNER_IMAGE }}
+          oci-image-shape: "VM.Standard.E4.Flex"
           runners-count: '1'
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'

--- a/.github/workflows/graalvm-oci.yml
+++ b/.github/workflows/graalvm-oci.yml
@@ -34,7 +34,7 @@ jobs:
           oci-subnet-ocid: ${{ secrets.OCI_SUBNET }}
           oci-av-domain: ${{ secrets.OCI_AV_DOMAIN }}
           oci-image-ocid: ${{ secrets.OCI_RUNNER_IMAGE }}
-          oci-image-shape: "VM.Standard.E4.Flex"
+          oci-image-shape: "VM.Standard.E4.4"
           runners-count: '1'
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'

--- a/.github/workflows/graalvm-oci.yml
+++ b/.github/workflows/graalvm-oci.yml
@@ -43,7 +43,6 @@ jobs:
       matrix:
         java: [ '17' ]
     steps:
-      - uses: AutoModality/action-clean@v1.1.1
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/ManagedNettyHttpProvider.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/ManagedNettyHttpProvider.java
@@ -18,7 +18,9 @@ package io.micronaut.oraclecloud.httpclient.netty;
 import com.oracle.bmc.http.client.HttpClientBuilder;
 import com.oracle.bmc.http.client.HttpProvider;
 import com.oracle.bmc.http.client.Serializer;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.json.JsonMapper;
@@ -42,17 +44,22 @@ import java.util.concurrent.ExecutorService;
  */
 @Singleton
 @Internal
+@BootstrapContextCompatible
 public class ManagedNettyHttpProvider implements HttpProvider {
     static final String SERVICE_ID = "oci";
 
     final HttpClient mnHttpClient;
+    /**
+     * {@code null} in bootstrap context.
+     */
+    @Nullable
     final ExecutorService ioExecutor;
     final JsonMapper jsonMapper;
 
     @Inject
     public ManagedNettyHttpProvider(
         @Client(id = SERVICE_ID) HttpClient mnHttpClient,
-        @Named(TaskExecutors.BLOCKING) ExecutorService ioExecutor,
+        @Named(TaskExecutors.BLOCKING) @Nullable ExecutorService ioExecutor,
         ObjectMapper jsonMapper,
         OciSerdeConfiguration ociSerdeConfiguration,
         OciSerializationConfiguration ociSerializationConfiguration

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
@@ -29,6 +29,7 @@ import io.micronaut.http.client.netty.DefaultHttpClient;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.oraclecloud.serde.OciSdkMicronautSerializer;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.PrematureChannelClosureException;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -51,6 +52,7 @@ final class NettyHttpClient implements HttpClient {
     private static final Map<ClientProperty<?>, Object> EXPECTED_PROPERTIES;
 
     final boolean hasContext;
+    final boolean ownsThreadPool;
     final URI baseUri;
     final List<RequestInterceptor> requestInterceptors;
     final ExecutorService blockingIoExecutor;
@@ -75,6 +77,7 @@ final class NettyHttpClient implements HttpClient {
         DefaultHttpClient mnClient;
         if (builder.managedProvider == null) {
             hasContext = false;
+            ownsThreadPool = true;
             DefaultHttpClientConfiguration cfg = new DefaultHttpClientConfiguration();
             if (builder.properties.containsKey(StandardClientProperties.CONNECT_TIMEOUT)) {
                 cfg.setConnectTimeout((Duration) builder.properties.get(StandardClientProperties.CONNECT_TIMEOUT));
@@ -93,7 +96,13 @@ final class NettyHttpClient implements HttpClient {
                 }
             }
             mnClient = (DefaultHttpClient) builder.managedProvider.mnHttpClient;
-            blockingIoExecutor = builder.managedProvider.ioExecutor;
+            if (builder.managedProvider.ioExecutor == null) {
+                ownsThreadPool = true;
+                blockingIoExecutor = Executors.newCachedThreadPool();
+            } else {
+                ownsThreadPool = false;
+                blockingIoExecutor = builder.managedProvider.ioExecutor;
+            }
             jsonMapper = builder.managedProvider.jsonMapper;
         }
         upstreamHttpClient = mnClient;
@@ -120,7 +129,8 @@ final class NettyHttpClient implements HttpClient {
 
     @Override
     public boolean isProcessingException(Exception e) {
-        return e instanceof JacksonException;
+        // these exceptions will allow the client to retry the request
+        return e instanceof JacksonException || e instanceof PrematureChannelClosureException;
     }
 
     @Override
@@ -131,6 +141,8 @@ final class NettyHttpClient implements HttpClient {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+        if (ownsThreadPool) {
             blockingIoExecutor.shutdown();
         }
     }

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/OciServiceInstanceList.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/OciServiceInstanceList.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.httpclient.netty;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.discovery.ServiceInstance;
+import io.micronaut.discovery.ServiceInstanceList;
+import io.micronaut.http.client.loadbalance.DiscoveryClientLoadBalancerFactory;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+/**
+ * This is necessary to get the {@link ManagedNettyHttpProvider} working in the bootstrap context.
+ */
+@BootstrapContextCompatible
+@Singleton
+@Internal
+@Requires(missingBeans = DiscoveryClientLoadBalancerFactory.class)
+final class OciServiceInstanceList implements ServiceInstanceList {
+    @Override
+    public String getID() {
+        return ManagedNettyHttpProvider.SERVICE_ID;
+    }
+
+    @Override
+    public List<ServiceInstance> getInstances() {
+        return List.of();
+    }
+}

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerdeConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerdeConfiguration.java
@@ -16,6 +16,7 @@
 package io.micronaut.oraclecloud.serde;
 
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
@@ -24,6 +25,7 @@ import io.micronaut.serde.config.SerdeConfiguration;
 @ConfigurationProperties("oci.serde")
 @Bean(typed = OciSerdeConfiguration.class)
 @Internal
+@BootstrapContextCompatible
 public interface OciSerdeConfiguration extends SerdeConfiguration {
     @Override
     @Bindable(defaultValue = "false")

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerializationConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerializationConfiguration.java
@@ -16,6 +16,7 @@
 package io.micronaut.oraclecloud.serde;
 
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
@@ -25,6 +26,7 @@ import io.micronaut.serde.config.annotation.SerdeConfig;
 @ConfigurationProperties("oci.serde.serialization")
 @Bean(typed = OciSerializationConfiguration.class)
 @Internal
+@BootstrapContextCompatible
 public interface OciSerializationConfiguration extends SerializationConfiguration {
     @Bindable(defaultValue = "NON_NULL")
     @Override


### PR DESCRIPTION
In NettyHttpClient#isProcessingException, return true for PrematureChannelClosureException. This lets the client retry the request for that exception.

Also had to make a few changes to make ManagedNettyHttpProvider work in the bootstrap context.