### PR TITLE
Add shared, lazy SessionKeySupplier implementation

### DIFF
--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/LazySessionKeySupplier.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/LazySessionKeySupplier.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.core;
+
+import com.oracle.bmc.auth.SessionKeySupplier;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Secondary;
+import jakarta.inject.Singleton;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * {@link SessionKeySupplier} implementation that lazily generates RSA keys to avoid generating keys
+ * that go unused. This is a singleton that is used for all session keys in the application context.
+ * <p>
+ * Ideally this should also be shared with the bootstrap context in the future.
+ *
+ * @since 4.2.0
+ * @author Jonas Konrad
+ */
+@Singleton
+@Secondary
+@BootstrapContextCompatible
+final class LazySessionKeySupplier implements SessionKeySupplier {
+    private static final KeyPairGenerator GENERATOR;
+
+    private final Lock lock = new ReentrantLock();
+    private volatile KeyPair keyPair = null;
+
+    static {
+        try {
+            GENERATOR = KeyPairGenerator.getInstance("RSA");
+            GENERATOR.initialize(2048);
+        } catch (NoSuchAlgorithmException e) {
+            throw new Error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public KeyPair getKeyPair() {
+        KeyPair kp = keyPair;
+        if (kp == null) {
+            lock.lock();
+            try {
+                kp = keyPair;
+                if (kp == null) {
+                    kp = GENERATOR.generateKeyPair();
+                    keyPair = kp;
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+        return kp;
+    }
+
+    @Override
+    public void refreshKeys() {
+        keyPair = null;
+    }
+}

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
@@ -21,24 +21,25 @@ import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SessionKeySupplier;
 import com.oracle.bmc.auth.SessionTokenAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.URLBasedX509CertificateSupplier;
 import com.oracle.bmc.auth.internal.AuthUtils;
-import io.micronaut.context.annotation.Property;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.context.exceptions.DisabledBeanException;
-
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataConfiguration;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -76,6 +77,10 @@ public class OracleCloudCoreFactory {
     public static final String OKE_WORKLOAD_IDENTITY_PREFIX = OracleCloudCoreFactory.ORACLE_CLOUD + ".config.oke-workload-identity";
 
     private OracleCloudConfigFileConfigurationProperties ociConfigFileConfiguration;
+
+    @Inject
+    @Nullable
+    SessionKeySupplier sessionKeySupplier;
 
     /**
      * @param profile The configured profile
@@ -156,7 +161,11 @@ public class OracleCloudCoreFactory {
     @Primary
     @BootstrapContextCompatible
     protected ResourcePrincipalAuthenticationDetailsProvider resourcePrincipalAuthenticationDetailsProvider() {
-        return ResourcePrincipalAuthenticationDetailsProvider.builder().build();
+        ResourcePrincipalAuthenticationDetailsProvider.ResourcePrincipalAuthenticationDetailsProviderBuilder builder = ResourcePrincipalAuthenticationDetailsProvider.builder();
+        if (sessionKeySupplier != null) {
+            builder.sessionKeySupplier(sessionKeySupplier);
+        }
+        return builder.build();
     }
 
     /**
@@ -172,7 +181,11 @@ public class OracleCloudCoreFactory {
     @Primary
     @BootstrapContextCompatible
     protected InstancePrincipalsAuthenticationDetailsProvider instancePrincipalAuthenticationDetailsProvider(InstancePrincipalConfiguration instancePrincipalConfiguration) {
-        return instancePrincipalConfiguration.getBuilder().build();
+        InstancePrincipalsAuthenticationDetailsProvider.InstancePrincipalsAuthenticationDetailsProviderBuilder builder = instancePrincipalConfiguration.getBuilder();
+        if (sessionKeySupplier != null) {
+            builder.sessionKeySupplier(sessionKeySupplier);
+        }
+        return builder.build();
     }
 
     /**

--- a/oraclecloud-oke-workload-identity/src/main/java/io/micronaut/oraclecloud/oke/workload/identity/OkeWorkloadIdentityFactory.java
+++ b/oraclecloud-oke-workload-identity/src/main/java/io/micronaut/oraclecloud/oke/workload/identity/OkeWorkloadIdentityFactory.java
@@ -18,12 +18,15 @@ package io.micronaut.oraclecloud.oke.workload.identity;
 import com.oracle.bmc.auth.AuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SessionKeySupplier;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.okeworkloadidentity.OkeWorkloadIdentityAuthenticationDetailsProvider;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 /**
@@ -42,6 +45,9 @@ import jakarta.inject.Singleton;
 @Factory
 @BootstrapContextCompatible
 public class OkeWorkloadIdentityFactory {
+    @Inject
+    @Nullable
+    SessionKeySupplier sessionKeySupplier;
 
     /**
      * Configures a {@link OkeWorkloadIdentityAuthenticationDetailsProvider} if no other {@link AuthenticationDetailsProvider} is present and
@@ -56,7 +62,11 @@ public class OkeWorkloadIdentityFactory {
     @Primary
     @BootstrapContextCompatible
     protected OkeWorkloadIdentityAuthenticationDetailsProvider okeWorkloadIdentityAuthenticationDetailsProvider(OkeWorkloadIdentityConfiguration okeWorkloadIdentityConfiguration) {
-        return okeWorkloadIdentityConfiguration.getBuilder().build();
+        OkeWorkloadIdentityAuthenticationDetailsProvider.OkeWorkloadIdentityAuthenticationDetailsProviderBuilder builder = okeWorkloadIdentityConfiguration.getBuilder();
+        if (sessionKeySupplier != null) {
+            builder.sessionKeySupplier(sessionKeySupplier);
+        }
+        return builder.build();
     }
 
 }


### PR DESCRIPTION
During startup, prof shows that a significant time is spent inside RSA key generation in the default SessionKeySupplierImpl, both in the constructor and in refreshKeys. This PR adds a new implementation that avoids generating keys until first time of use, and shares the session key between authorization providers.

Sharing between bootstrap and normal context is not yet implemented.

I have no way to test this, so can't say how much it helps.