### PR TITLE
Don't set url to the datasource user property in the datasource wallet Configurator

### DIFF
--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/wallet/datasource/OracleDataSourceAttributesBase.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/wallet/datasource/OracleDataSourceAttributesBase.java
@@ -114,7 +114,7 @@ class OracleDataSourceAttributesBase<T extends OracleDataSourceAttributes>
                 dataSource.setURL(url);
             }
             if (user != null) {
-                dataSource.setUser(url);
+                dataSource.setUser(user);
             }
             if (password != null) {
                 dataSource.setPassword(new String(password));


### PR DESCRIPTION
Saw this while debugging something else related to the Oracle ATP. There were no tests before and not sure how to add it. Also, maybe this code path is not used ever (username is null always?) but probably won't cause issues if we just fix it.