### PR TITLE
Fixes error handling reading secrets

### DIFF
--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/filter/ExplicitlySetPropertyFilter.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/filter/ExplicitlySetPropertyFilter.java
@@ -16,6 +16,7 @@
 package io.micronaut.oraclecloud.serde.filter;
 
 import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.serde.PropertyFilter;
 import io.micronaut.serde.Serializer;
@@ -36,6 +37,7 @@ import jakarta.inject.Singleton;
 @Internal
 @Singleton
 @Named(ExplicitlySetBmcModel.EXPLICITLY_SET_FILTER_NAME)
+@BootstrapContextCompatible
 final class ExplicitlySetPropertyFilter implements PropertyFilter {
 
     @Override

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/ErrorCodeAndMessageDeserializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/ErrorCodeAndMessageDeserializer.java
@@ -16,6 +16,7 @@
 package io.micronaut.oraclecloud.serde.serializers;
 
 import com.oracle.bmc.http.internal.ResponseHelper;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
@@ -33,6 +34,7 @@ import java.util.Map;
  */
 @Internal
 @Singleton
+@BootstrapContextCompatible
 final class ErrorCodeAndMessageDeserializer implements Deserializer<ResponseHelper.ErrorCodeAndMessage> {
 
     @Override

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/SessionTokenDeserializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/SessionTokenDeserializer.java
@@ -16,6 +16,7 @@
 package io.micronaut.oraclecloud.serde.serializers;
 
 import com.oracle.bmc.auth.SessionTokenAuthenticationDetailsProvider.SessionToken;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
@@ -36,6 +37,7 @@ import java.io.IOException;
  */
 @Internal
 @Singleton
+@BootstrapContextCompatible
 final class SessionTokenDeserializer implements CustomizableDeserializer<SessionToken> {
 
     @Override

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/SessionTokenRequestSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/SessionTokenRequestSerializer.java
@@ -16,6 +16,7 @@
 package io.micronaut.oraclecloud.serde.serializers;
 
 import com.oracle.bmc.auth.SessionTokenAuthenticationDetailsProvider.SessionTokenRefreshRequest.SessionTokenRequest;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
@@ -32,6 +33,7 @@ import java.io.IOException;
  */
 @Internal
 @Singleton
+@BootstrapContextCompatible
 final class SessionTokenRequestSerializer implements Serializer<SessionTokenRequest> {
 
     @Override


### PR DESCRIPTION
If an error occurs reading secrets this leads to 

```
java.lang.IllegalAccessError: cla
ss io.micronaut.oraclecloud.serde.$com_oracle_bmc_http_internal_ResponseHelper$ErrorCodeAndMessage$Introspection tried to access method 'void com.oracle.bmc.http.internal.ResponseHelper$ErrorCodeAndMessage.<init>(j
ava.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Map)' (io.micronaut.oraclecloud.serde.$com_oracle_bmc_http_internal_ResponseHelper$ErrorCodeAndMessage$Introspection and com.oracle.b
mc.http.internal.ResponseHelper$ErrorCodeAndMessage are in unnamed module of loader 'app')
```

This is because some deserializers are not loaded in the bootstrap context.

Every bean that is needed by the client needs to be compatible with this context.

Note that it is unclear how I can test this.