### PR TITLE
Remove http client registry from metrics

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -22,7 +22,6 @@ import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.client.HttpClientRegistry;
 import io.micronaut.oraclecloud.core.TenancyIdProvider;
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudConfig;
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudMeterRegistry;
@@ -123,7 +122,7 @@ public class OracleCloudMeterRegistryFactory {
     @Bean(preDestroy = "close")
     @Requires(property = MeterRegistryFactory.MICRONAUT_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
     @Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_RAW_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.FALSE)
-    OracleCloudRawMeterRegistry oracleCloudRawMeterRegistry(HttpClientRegistry<?> httpClientRegistry, OracleCloudConfig oracleCloudConfig, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
-        return new OracleCloudRawMeterRegistry(httpClientRegistry, oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
+    OracleCloudRawMeterRegistry oracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
+        return new OracleCloudRawMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -25,7 +25,6 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.lang.Nullable;
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
-import io.micronaut.http.client.HttpClientRegistry;
 import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient;
 import jakarta.inject.Provider;
 import org.slf4j.Logger;
@@ -54,24 +53,6 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
         config().namingConvention(new OracleCloudMetricsNamingConvention());
         config().commonTags("application", this.oracleCloudConfig.applicationName());
         start(threadFactory);
-    }
-
-    /**
-     *
-     * @param httpClientRegistry Http Client Registry
-     * @param oracleCloudConfig Oracle Cloud Config
-     * @param clock Clock
-     * @param monitoringIngestionClientProvider Monitoring Ingestion Client Provider
-     * @param threadFactory Thread Factory
-     * @deprecated Use {@link AbstractOracleCloudMeterRegistry(OracleCloudConfig, Clock, Provider, ThreadFactory)} instead.
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    protected AbstractOracleCloudMeterRegistry(HttpClientRegistry<?> httpClientRegistry,
-                                               OracleCloudConfig oracleCloudConfig,
-                                               Clock clock,
-                                               Provider<MonitoringIngestionClient> monitoringIngestionClientProvider,
-                                               ThreadFactory threadFactory) {
-        this(oracleCloudConfig, clock, monitoringIngestionClientProvider, threadFactory);
     }
 
     @Override

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistry.java
@@ -30,7 +30,6 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.lang.Nullable;
-import io.micronaut.http.client.HttpClientRegistry;
 import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient;
 import jakarta.inject.Provider;
 
@@ -38,7 +37,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -63,40 +61,6 @@ public class OracleCloudMeterRegistry extends AbstractOracleCloudMeterRegistry {
                                     Clock clock,
                                     Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
         super(oracleCloudConfig, clock, monitoringIngestionClientProvider, new NamedThreadFactory("oraclecloud-metrics-publisher"));
-    }
-
-    /**
-     *
-     * @param httpClientRegistry Http Client Registry
-     * @param oracleCloudConfig Oracle Cloud Config
-     * @param clock Clock
-     * @param monitoringIngestionClientProvider Monitoring Ingestion Client Provider
-     * @deprecated Use {@link OracleCloudMeterRegistry(OracleCloudConfig, Clock, Provider, ThreadFactory)} instead.
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public OracleCloudMeterRegistry(HttpClientRegistry<?> httpClientRegistry,
-                                    OracleCloudConfig oracleCloudConfig,
-                                    Clock clock,
-                                    Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
-        this(httpClientRegistry, oracleCloudConfig, clock, monitoringIngestionClientProvider, new NamedThreadFactory("oraclecloud-metrics-publisher"));
-    }
-
-    /**
-     *
-     * @param httpClientRegistry Http Client Registry
-     * @param oracleCloudConfig Oracle Cloud Config
-     * @param clock Clock
-     * @param monitoringIngestionClientProvider Monitoring Ingestion Client Provider
-     * @param threadFactory Thread Factory
-     * @deprecated Use {@link OracleCloudMeterRegistry(OracleCloudConfig, Clock, Provider, ThreadFactory)} instead.
-     */
-    @Deprecated(forRemoval = true, since = "4.3.0")
-    public OracleCloudMeterRegistry(HttpClientRegistry<?> httpClientRegistry,
-                                    OracleCloudConfig oracleCloudConfig,
-                                    Clock clock,
-                                    Provider<MonitoringIngestionClient> monitoringIngestionClientProvider,
-                                    ThreadFactory threadFactory) {
-        super(httpClientRegistry, oracleCloudConfig, clock, monitoringIngestionClientProvider, threadFactory);
     }
 
     /**

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -33,7 +33,6 @@ import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.lang.Nullable;
-import io.micronaut.http.client.HttpClientRegistry;
 import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient;
 import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudDatapointProducer;
 import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudCounter;
@@ -47,7 +46,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -62,18 +60,10 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
 
     private final Logger logger = LoggerFactory.getLogger(OracleCloudRawMeterRegistry.class);
 
-    public OracleCloudRawMeterRegistry(HttpClientRegistry<?> httpClientRegistry, OracleCloudConfig oracleCloudConfig,
-                                       Clock clock,
-                                       Provider<MonitoringIngestionClient> monitoringIngestionClientProvider
-                                       ) {
-        this(httpClientRegistry, oracleCloudConfig, clock, monitoringIngestionClientProvider, new NamedThreadFactory("oraclecloud-metrics-publisher"));
-    }
-
-    public OracleCloudRawMeterRegistry(HttpClientRegistry<?> httpClientRegistry,
+    public OracleCloudRawMeterRegistry(
                                        OracleCloudConfig oracleCloudConfig,
-                                       Clock clock, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider,
-                                       ThreadFactory threadFactory) {
-        super(httpClientRegistry, oracleCloudConfig, clock, monitoringIngestionClientProvider, threadFactory);
+                                       Clock clock, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
+        super(oracleCloudConfig, clock, monitoringIngestionClientProvider, new NamedThreadFactory("oraclecloud-metrics-publisher"));
 
     }
 

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -212,7 +212,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
         if (meter instanceof OracleCloudDatapointProducer oracleCloudDatapointProducer) {
             return Stream.of(metricDataDetails(meter.getId(), null, oracleCloudDatapointProducer.getDatapoints()));
         }
-        logger.error("Metrics name: %s. Haven't publish metrics for class: %s".formatted(meter.getId().toString(), meter.getClass()));
+        logger.error("Metrics name: {}. Haven't publish metrics for class: {}",meter.getId(), meter.getClass());
         return Stream.empty();
     }
 

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
@@ -1,9 +1,7 @@
 package io.micronaut.oraclecloud.monitoring.micrometer
 
-import com.oracle.bmc.monitoring.MonitoringClient
 import com.oracle.bmc.monitoring.model.Datapoint
 import io.micrometer.core.instrument.*
-import io.micronaut.http.client.HttpClientRegistry
 import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient
 import jakarta.inject.Provider
 import spock.lang.AutoCleanup
@@ -47,7 +45,7 @@ class OracleCloudMeterRawRegistrySpec extends Specification {
 
     @AutoCleanup
     @Shared
-    private OracleCloudRawMeterRegistry cloudMeterRegistry = new OracleCloudRawMeterRegistry(Mock(HttpClientRegistry.class), oracleCloudConfig, mockClock, new Provider<MonitoringIngestionClient>() {
+    private OracleCloudRawMeterRegistry cloudMeterRegistry = new OracleCloudRawMeterRegistry(oracleCloudConfig, mockClock, new Provider<MonitoringIngestionClient>() {
         @Override
         MonitoringIngestionClient get() {
             monitoringClient


### PR DESCRIPTION
The PR removes unnecessary constructors to both MeterRegistries. The HttpClientRegistry was added before because of issue with the graceful shutdown the clients were alive even when the downstream netty client was closed. Now it just causes issue with circular dependency with Executor-s.