### PR TITLE
Move the region provider to the sdk client factory constructor and make it optional

### DIFF
--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudCoreFactory.java
@@ -76,11 +76,11 @@ public class OracleCloudCoreFactory {
 
     public static final String OKE_WORKLOAD_IDENTITY_PREFIX = OracleCloudCoreFactory.ORACLE_CLOUD + ".config.oke-workload-identity";
 
-    private OracleCloudConfigFileConfigurationProperties ociConfigFileConfiguration;
-
     @Inject
     @Nullable
     SessionKeySupplier sessionKeySupplier;
+
+    private OracleCloudConfigFileConfigurationProperties ociConfigFileConfiguration;
 
     /**
      * @param profile The configured profile

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
@@ -56,13 +56,14 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
     ) {
         this.builder = Objects.requireNonNull(builder, "Builder cannot be null");
         builder.configuration(Objects.requireNonNull(clientConfiguration, "Client configuration cannot be null"));
-        if (clientConfigurator != null) {
-            builder.clientConfigurator(clientConfigurator);
-        }
         if (regionProvider != null && regionProvider.getRegion() != null
+            && !(regionProvider instanceof AbstractAuthenticationDetailsProvider)
             && builder instanceof RegionalClientBuilder<?, ?> regional
         ) {
             regional.region(regionProvider.getRegion());
+        }
+        if (clientConfigurator != null) {
+            builder.clientConfigurator(clientConfigurator);
         }
         if (requestSignerFactory != null) {
             builder.requestSignerFactory(requestSignerFactory);

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
@@ -19,6 +19,7 @@ import com.oracle.bmc.ClientConfiguration;
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.RegionProvider;
 import com.oracle.bmc.common.ClientBuilderBase;
+import com.oracle.bmc.common.RegionalClientBuilder;
 import com.oracle.bmc.http.ClientConfigurator;
 import com.oracle.bmc.http.client.HttpProvider;
 import com.oracle.bmc.http.signing.RequestSignerFactory;
@@ -44,16 +45,24 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
      * @param clientConfiguration The client config
      * @param clientConfigurator The client configurator (optional)
      * @param requestSignerFactory The request signer factory (optional)
+     * @param regionProvider The region provider (optional)
      */
     protected AbstractSdkClientFactory(
             B builder,
             ClientConfiguration clientConfiguration,
             @Nullable ClientConfigurator clientConfigurator,
-            @Nullable RequestSignerFactory requestSignerFactory) {
+            @Nullable RequestSignerFactory requestSignerFactory,
+            @Nullable RegionProvider regionProvider
+    ) {
         this.builder = Objects.requireNonNull(builder, "Builder cannot be null");
         builder.configuration(Objects.requireNonNull(clientConfiguration, "Client configuration cannot be null"));
         if (clientConfigurator != null) {
             builder.clientConfigurator(clientConfigurator);
+        }
+        if (regionProvider != null && regionProvider.getRegion() != null
+                && builder instanceof RegionalClientBuilder<?,?> regional
+        ) {
+            regional.region(regionProvider.getRegion());
         }
         if (requestSignerFactory != null) {
             builder.requestSignerFactory(requestSignerFactory);
@@ -73,14 +82,12 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
      *
      * @param clientBuilder The builder for client
      * @param authenticationDetailsProvider The authentication details provider
-     * @param regionProvider The region provider
      * @return The client to build
      */
     protected abstract @NonNull T build(
         @NonNull B clientBuilder,
-        @NonNull AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
-        @NonNull RegionProvider regionProvider
-        );
+        @NonNull AbstractAuthenticationDetailsProvider authenticationDetailsProvider
+    );
 
     /**
      * Set the HTTP provider for this client. This is injected by the application context, in order

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
@@ -60,7 +60,7 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
             builder.clientConfigurator(clientConfigurator);
         }
         if (regionProvider != null && regionProvider.getRegion() != null
-                && builder instanceof RegionalClientBuilder<?,?> regional
+            && builder instanceof RegionalClientBuilder<?, ?> regional
         ) {
             regional.region(regionProvider.getRegion());
         }

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciMonitoringSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciMonitoringSpec.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.oraclecloud.client
 
+import com.oracle.bmc.Service
+import com.oracle.bmc.Services
 import com.oracle.bmc.auth.AuthenticationDetailsProvider
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider
 import com.oracle.bmc.auth.RegionProvider
@@ -92,7 +94,11 @@ class OciMonitoringSpec extends Specification {
     }
 
     MonitoringClient createTelemetryClient() {
-        String ingestionEndpoint = regionProvider.getRegion().getEndpoint(MonitoringClient.SERVICE).orElseThrow()
+        Service service = Services.serviceBuilder().serviceName("MONITORING")
+                .serviceEndpointPrefix("telemetry-ingestion")
+                .serviceEndpointTemplate("https://telemetry-ingestion.{region}.{secondLevelDomain}")
+                .build()
+        String ingestionEndpoint = regionProvider.getRegion().getEndpoint(service).orElseThrow()
         return MonitoringClient.builder().endpoint(ingestionEndpoint).build(authenticationDetailsProvider)
     }
 

--- a/oraclecloud-sdk-processor/src/main/java/io/micronaut/oraclecloud/clients/processor/OracleCloudSdkProcessor.java
+++ b/oraclecloud-sdk-processor/src/main/java/io/micronaut/oraclecloud/clients/processor/OracleCloudSdkProcessor.java
@@ -93,9 +93,7 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
      */
     public static final String OCI_SDK_CLIENT_CLASSES_OPTION = "ociSdkClientClasses";
 
-    private static final String RETURN_BUILDER_STATEMENT_WITH_REGION = "return regionProvider.getRegion() != null ? clientBuilder.region(regionProvider.getRegion()).build(authenticationDetailsProvider) : clientBuilder.build(authenticationDetailsProvider)";
-    private static final String RETURN_BUILDER_STATEMENT_WITHOUT_REGION = "return clientBuilder.build(authenticationDetailsProvider)";
-    private static final List<String> FACTORIES_THAT_DOESNT_SUPPORT_REGION = List.of("KmsCrypto", "KmsManagement", "IdentityDomains", "Stream");
+    private static final String RETURN_BUILDER = "return clientBuilder.build(authenticationDetailsProvider)";
 
     private Filer filer;
     private Messager messager;
@@ -364,7 +362,6 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
         builder.addField(FieldSpec.builder(builderType, "builder", Modifier.PRIVATE).build());
         builder.addAnnotation(Factory.class);
         final ClassName authProviderType = ClassName.get("com.oracle.bmc.auth", "AbstractAuthenticationDetailsProvider");
-        final ClassName regionProvider = ClassName.get("com.oracle.bmc.auth", "RegionProvider");
         final AnnotationSpec.Builder requiresSpec = AnnotationSpec.builder(Requires.class)
                 .addMember("classes", simpleName + ".class")
                 .addMember("beans", authProviderType.canonicalName() + ".class");
@@ -396,12 +393,11 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
         buildMethod.returns(ClassName.get(packageName, simpleName))
                 .addParameter(builderType, "clientBuilder")
                 .addParameter(authProviderType, "authenticationDetailsProvider")
-                .addParameter(regionProvider, "regionProvider")
-            .addAnnotation(Singleton.class)
+                .addAnnotation(Singleton.class)
                 .addAnnotation(requiresSpec.build())
                 .addAnnotation(preDestroy.build())
                 .addModifiers(Modifier.PROTECTED)
-                .addStatement(FACTORIES_THAT_DOESNT_SUPPORT_REGION.stream().noneMatch(factoryName::startsWith) ? RETURN_BUILDER_STATEMENT_WITH_REGION : RETURN_BUILDER_STATEMENT_WITHOUT_REGION);
+                .addStatement(RETURN_BUILDER);
         if (isBootstrapCompatible) {
             buildMethod.addAnnotation(BootstrapContextCompatible.class);
         }
@@ -440,8 +436,10 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
                                 .addAnnotation(Nullable.class).build())
                 .addParameter(ParameterSpec.builder(ClassName.get("com.oracle.bmc.http.signing", "RequestSignerFactory"), "requestSignerFactory")
                                 .addAnnotation(Nullable.class).build())
+                .addParameter(ParameterSpec.builder(ClassName.get("com.oracle.bmc.auth", "RegionProvider"), "regionProvider")
+                                .addAnnotation(Nullable.class).build())
                 .addCode(CodeBlock.builder()
-                        .addStatement("super(" + simpleName + ".builder(), clientConfiguration, clientConfigurator, requestSignerFactory)")
+                        .addStatement("super(" + simpleName + ".builder(), clientConfiguration, clientConfigurator, requestSignerFactory, regionProvider)")
                         .addStatement("builder = super.getBuilder()").build());
         builder.addModifiers(Modifier.PUBLIC, Modifier.FINAL);
         return constructor;


### PR DESCRIPTION
This will avoid overwriting endpoint if one was set by user.

See setRegion implementation inside client:
```
protected void setRegion(Region region) {
        this.region = region;
        ...

        Optional<String> endpoint = region.getEndpoint(this.service);
        if (endpoint.isPresent()) {
            this.setEndpoint((String)endpoint.get());
        } else {
            throw new IllegalArgumentException("Endpoint for " + this.service + " is not known in region " + region);
        }
    }
```
