### PR TITLE
OCI SDK doesn't have service with telemetry-ingestion so we create one

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/MonitoringIngestionClient.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/MonitoringIngestionClient.java
@@ -16,6 +16,8 @@
 package io.micronaut.oraclecloud.monitoring;
 
 import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.Service;
+import com.oracle.bmc.Services;
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.RegionProvider;
 import com.oracle.bmc.http.ClientConfigurator;
@@ -41,6 +43,7 @@ import java.util.Objects;
  */
 @Singleton
 public class MonitoringIngestionClient {
+    public static final Service SERVICE = Services.serviceBuilder().serviceName("MONITORING-INGESTION").serviceEndpointPrefix("telemetry-ingestion").serviceEndpointTemplate("https://telemetry-ingestion.{region}.{secondLevelDomain}").build();
 
     private final ClientConfiguration clientConfiguration;
     private final ClientConfigurator clientConfigurator;
@@ -109,7 +112,7 @@ public class MonitoringIngestionClient {
                         throw new IllegalArgumentException("Region is required for the Monitoring Ingestion client");
                     }
 
-                    String ingestionEndpoint = regionProvider.getRegion().getEndpoint(MonitoringClient.SERVICE)
+                    String ingestionEndpoint = regionProvider.getRegion().getEndpoint(MonitoringIngestionClient.SERVICE)
                         .orElse(String.format("https://telemetry-ingestion.%s.oraclecloud.com", regionProvider.getRegion().getRegionId()));
 
                     MonitoringClient.Builder builder = MonitoringClient.builder().

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMonitorClientEndpointUsingRegionProviderSpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMonitorClientEndpointUsingRegionProviderSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.oraclecloud.monitoring.micrometer
+
+import com.oracle.bmc.Region
+import com.oracle.bmc.auth.RegionProvider
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.*
+import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+@Property(name="micronaut.metrics.export.oraclecloud.enabled", value = "false")
+@Property(name="spec.name", value = "OracleCloudMonitorClientEndpointUsingRegionProviderSpec")
+class OracleCloudMonitorClientEndpointUsingRegionProviderSpec extends Specification {
+
+    @Inject
+    ApplicationContext context
+
+    def "test oci sdk metrics client filter request returns exception" () {
+        when:
+        MonitoringIngestionClient monitoringIngestionClient = context.getBean(MonitoringIngestionClient)
+        def delegate = monitoringIngestionClient.getDelegate()
+
+        then:
+        delegate.getEndpoint() == "https://telemetry-ingestion.eu-jovanovac-1.oraclecloud20.com"
+    }
+
+    @Singleton
+    @BootstrapContextCompatible
+    @Primary
+    @Replaces(RegionProvider.class)
+    @Requires(property = "spec.name", value = "OracleCloudMonitorClientEndpointUsingRegionProviderSpec")
+    static class RegionProviderReplacement implements RegionProvider {
+
+        @Override
+        Region getRegion() {
+            return Region.EU_JOVANOVAC_1
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes metrics endpoint, the prefix should be `telemetry-ingestion` instead of `telemetry`.