### PR TITLE
Fix custom endpoints for oci builder clients

### DIFF
--- a/docs-examples/example-kotlin/src/test/java/example/mock/MockAuthenticationDetailsProvider.java
+++ b/docs-examples/example-kotlin/src/test/java/example/mock/MockAuthenticationDetailsProvider.java
@@ -3,6 +3,7 @@ package example.mock;
 import com.oracle.bmc.auth.AuthCachingPolicy;
 import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Replaces;
 
 import jakarta.inject.Singleton;
@@ -11,6 +12,7 @@ import java.io.InputStream;
 @AuthCachingPolicy(cacheKeyId = false, cachePrivateKey = false)
 @Singleton
 @Replaces(ConfigFileAuthenticationDetailsProvider.class)
+@Primary
 public class MockAuthenticationDetailsProvider implements BasicAuthenticationDetailsProvider {
 
     @Override

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
@@ -19,8 +19,6 @@ import com.oracle.bmc.ClientConfiguration;
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.RegionProvider;
 import com.oracle.bmc.common.ClientBuilderBase;
-import com.oracle.bmc.common.InternalBuilderAccess;
-import com.oracle.bmc.common.RegionalClientBuilder;
 import com.oracle.bmc.http.ClientConfigurator;
 import com.oracle.bmc.http.client.HttpProvider;
 import com.oracle.bmc.http.signing.RequestSignerFactory;
@@ -57,13 +55,6 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
     ) {
         this.builder = Objects.requireNonNull(builder, "Builder cannot be null");
         builder.configuration(Objects.requireNonNull(clientConfiguration, "Client configuration cannot be null"));
-        String endpoint = InternalBuilderAccess.getEndpoint(builder);
-        if (endpoint == null && regionProvider != null && regionProvider.getRegion() != null
-            && !(regionProvider instanceof AbstractAuthenticationDetailsProvider)
-            && builder instanceof RegionalClientBuilder<?, ?> regional
-        ) {
-            regional.region(regionProvider.getRegion());
-        }
 
         if (clientConfigurator != null) {
             builder.clientConfigurator(clientConfigurator);

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
@@ -19,6 +19,7 @@ import com.oracle.bmc.ClientConfiguration;
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.RegionProvider;
 import com.oracle.bmc.common.ClientBuilderBase;
+import com.oracle.bmc.common.InternalBuilderAccess;
 import com.oracle.bmc.common.RegionalClientBuilder;
 import com.oracle.bmc.http.ClientConfigurator;
 import com.oracle.bmc.http.client.HttpProvider;
@@ -56,12 +57,14 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
     ) {
         this.builder = Objects.requireNonNull(builder, "Builder cannot be null");
         builder.configuration(Objects.requireNonNull(clientConfiguration, "Client configuration cannot be null"));
-        if (regionProvider != null && regionProvider.getRegion() != null
+        String endpoint = InternalBuilderAccess.getEndpoint(builder);
+        if (endpoint !=null && regionProvider != null && regionProvider.getRegion() != null
             && !(regionProvider instanceof AbstractAuthenticationDetailsProvider)
             && builder instanceof RegionalClientBuilder<?, ?> regional
         ) {
             regional.region(regionProvider.getRegion());
         }
+
         if (clientConfigurator != null) {
             builder.clientConfigurator(clientConfigurator);
         }

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
@@ -58,7 +58,7 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
         this.builder = Objects.requireNonNull(builder, "Builder cannot be null");
         builder.configuration(Objects.requireNonNull(clientConfiguration, "Client configuration cannot be null"));
         String endpoint = InternalBuilderAccess.getEndpoint(builder);
-        if (endpoint != null && regionProvider != null && regionProvider.getRegion() != null
+        if (endpoint == null && regionProvider != null && regionProvider.getRegion() != null
             && !(regionProvider instanceof AbstractAuthenticationDetailsProvider)
             && builder instanceof RegionalClientBuilder<?, ?> regional
         ) {

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/AbstractSdkClientFactory.java
@@ -58,7 +58,7 @@ public abstract class AbstractSdkClientFactory<B extends ClientBuilderBase<B, T>
         this.builder = Objects.requireNonNull(builder, "Builder cannot be null");
         builder.configuration(Objects.requireNonNull(clientConfiguration, "Client configuration cannot be null"));
         String endpoint = InternalBuilderAccess.getEndpoint(builder);
-        if (endpoint !=null && regionProvider != null && regionProvider.getRegion() != null
+        if (endpoint != null && regionProvider != null && regionProvider.getRegion() != null
             && !(regionProvider instanceof AbstractAuthenticationDetailsProvider)
             && builder instanceof RegionalClientBuilder<?, ?> regional
         ) {

--- a/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
+++ b/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
@@ -51,7 +51,8 @@ public class ApacheNettyTest extends NettyTest {
 
     @Override
     protected void setupBootstrap(ServerBootstrap bootstrap) throws Exception {
-        socketDirectory = Files.createTempDirectory("oraclecloud-httpclient-apache");
+        // If prefix is too long the java.net.SocketException: Unix domain path too long will keep happening.
+        socketDirectory = Files.createTempDirectory("a");
         socketFile = socketDirectory.resolve("socket");
         bootstrap
             .channel(NioServerDomainSocketChannel.class)

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
@@ -1,0 +1,55 @@
+package io.micronaut.oraclecloud.client
+
+import com.oracle.bmc.Region
+import com.oracle.bmc.auth.AuthenticationDetailsProvider
+import com.oracle.bmc.auth.RegionProvider
+import com.oracle.bmc.monitoring.MonitoringClient
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+@Requires(bean = AuthenticationDetailsProvider)
+@Requires(bean = RegionProvider)
+@MicronautTest
+class OciCustomEndpointSpec extends Specification {
+
+    private static final CUSTOM_ENDPOINT = "https://this-is-my-custom-endpoint.com/test"
+
+    @Inject
+    @NonNull
+    AuthenticationDetailsProvider authenticationDetailsProvider
+
+    @Inject
+    MonitoringClient.Builder client
+
+    void "test get compartment"() {
+        when:
+        var client = buildClient()
+
+        then:
+        client.getEndpoint() == CUSTOM_ENDPOINT
+    }
+
+    MonitoringClient buildClient() {
+        return client.endpoint(CUSTOM_ENDPOINT).build(authenticationDetailsProvider)
+    }
+
+    @Singleton
+    @Primary
+    @Replaces(RegionProvider.class)
+    @Bean(typed = RegionProvider.class)
+    static class TestRegionProvider implements RegionProvider {
+
+        @Override
+        Region getRegion() {
+            return Region.EU_JOVANOVAC_1
+        }
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
@@ -1,8 +1,8 @@
 package io.micronaut.oraclecloud.client
 
 import com.oracle.bmc.Region
+import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
 import com.oracle.bmc.auth.AuthenticationDetailsProvider
-import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider
 import com.oracle.bmc.auth.RegionProvider
 import com.oracle.bmc.monitoring.MonitoringClient
 import io.micronaut.context.ApplicationContext
@@ -10,12 +10,13 @@ import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Factory
 import io.micronaut.context.env.Environment
+import io.micronaut.oraclecloud.httpclient.netty.MockAuthenticationDetailsProvider
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import spock.lang.Specification
-
 
 
 @Requires(bean = AuthenticationDetailsProvider)
@@ -28,11 +29,12 @@ class OciCustomEndpointSpec extends Specification {
     @Inject
     MonitoringClient.Builder client
 
-    void "test get compartment"() {
+    void "test custom endpoint"() {
 
         given:
         ApplicationContext context = ApplicationContext.run([
                 "spec.name"            : "OciCustomEndpointSpec",
+                "spec.name.provider"   : "OciCustomEndpointSpec",
                 "oci.config.enabled"   : "false"
 
         ], Environment.ORACLE_CLOUD)
@@ -47,68 +49,70 @@ class OciCustomEndpointSpec extends Specification {
         client.getEndpoint() == CUSTOM_ENDPOINT
     }
 
+    void "test custom region"() {
+
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "spec.name"            : "OciCustomEndpointSpec",
+                "spec.name.provider"   : "OciCustomEndpointSpec",
+                "oci.config.enabled"   : "false"
+
+        ], Environment.ORACLE_CLOUD)
+
+        when:
+        AuthenticationDetailsProvider authenticationDetailsProvider = context.getBean(AuthenticationDetailsProvider)
+        MonitoringClient.Builder clientBuilder = context.getBean(MonitoringClient.Builder)
+        var client = clientBuilder.region(Region.US_ASHBURN_1).build(authenticationDetailsProvider)
+
+        then:
+        MockAuthenticationDetailsProvider == authenticationDetailsProvider.getClass()
+        client.getEndpoint() == "https://telemetry.us-ashburn-1.oraclecloud.com"
+    }
+
+    void "test custom region factory"() {
+
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "spec.name"            : "OciCustomEndpointSpecFactory",
+                "spec.name.provider"   : "OciCustomEndpointSpec",
+                "oci.config.enabled"   : "false"
+
+        ], Environment.ORACLE_CLOUD)
+
+        when:
+        AuthenticationDetailsProvider authenticationDetailsProvider = context.getBean(AuthenticationDetailsProvider)
+        MonitoringClient client = context.getBean(MonitoringClient)
+
+        then:
+        MockAuthenticationDetailsProvider == authenticationDetailsProvider.getClass()
+        client.getEndpoint() == "https://telemetry.us-ashburn-1.oraclecloud.com"
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = "OciCustomEndpointSpecFactory")
+    static class FactoryReplacement {
+
+        @Singleton
+        @Requires(
+                classes = [MonitoringClient.class],
+                beans = [AbstractAuthenticationDetailsProvider.class]
+        )
+        @Replaces(MonitoringClient.Builder.class)
+        protected MonitoringClient.Builder builder() {
+            return new MonitoringClient.Builder(MonitoringClient.SERVICE).region(Region.US_ASHBURN_1);
+        }
+    }
+
     @Singleton
     @Primary
     @Replaces(RegionProvider.class)
     @Bean(typed = RegionProvider.class)
-    @Requires(property = "spec.name", value = "OciCustomEndpointSpec")
+    @Requires(property = "spec.name.provider", value = "OciCustomEndpointSpec")
     static class TestRegionProvider implements RegionProvider {
 
         @Override
         Region getRegion() {
             return Region.EU_JOVANOVAC_1
-        }
-    }
-
-    @Singleton
-    @Replaces(AuthenticationDetailsProvider.class)
-    @Primary
-    @Requires(property = "spec.name", value = "OciCustomEndpointSpec")
-    static class MockAuthenticationDetailsProvider implements AuthenticationDetailsProvider {
-        private static final String DUMMY_PEM_KEY = """
------BEGIN RSA PRIVATE KEY-----
-MIIBOAIBAAJAUczpZlq0T4QOr4F1RAg/lp0CJLn56ldrmis7bDQ1+XiC3/j7DzhP
-oLCd2PWHU/jniJdWAw6wESix/nb0xs/EiQIDAQABAkAqmNqyQmnDPrGnE3NNij4S
-4JBNL8vFDOEr13eKUWYKEvAAYEnscgyWQvGb7yvAQ5z/YBYatnAjakHRDO5kXtAB
-AiEAoQm2tcP3IiBm8BxstWKJlJ3xYA1euqLFdPnAaPQ5L6ECIQCCCYE0CSeLxgWw
-YqJyStqFbAzlUO1yarWIL3L61IeL6QIgenKQYxVmzKQmoVx7rFAInOCbsJV5+h/a
-VF+zVhqdgQECIEZZ3gzI5xw3hdxngHtVA+QrEM7/eXbtREjpYstRMAQBAiAy3g7Q
-ikw16ABtUnL1IVcwxBPZpSowDd5G3bcJyt+NSQ==
------END RSA PRIVATE KEY-----""";
-
-        @Override
-        String getKeyId() {
-            return null
-        }
-
-        @Override
-        InputStream getPrivateKey() {
-            return new ByteArrayInputStream(DUMMY_PEM_KEY.getBytes())
-        }
-
-        @Override
-        String getPassPhrase() {
-            return null
-        }
-
-        @Override
-        char[] getPassphraseCharacters() {
-            return new char[0]
-        }
-
-        @Override
-        String getFingerprint() {
-            return null
-        }
-
-        @Override
-        String getTenantId() {
-            return null
-        }
-
-        @Override
-        String getUserId() {
-            return null
         }
     }
 }

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
@@ -1,7 +1,10 @@
 package io.micronaut.oraclecloud.client
 
 import com.oracle.bmc.Region
+import com.oracle.bmc.auth.AuthCachingPolicy
 import com.oracle.bmc.auth.AuthenticationDetailsProvider
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider
 import com.oracle.bmc.auth.RegionProvider
 import com.oracle.bmc.monitoring.MonitoringClient
 import io.micronaut.context.annotation.Bean
@@ -53,6 +56,43 @@ class OciCustomEndpointSpec extends Specification {
         @Override
         Region getRegion() {
             return Region.EU_JOVANOVAC_1
+        }
+    }
+
+    @Singleton
+    @Replaces(ConfigFileAuthenticationDetailsProvider.class)
+    @Primary
+    @Requires(property = "spec.name", notEquals = "OciCustomEndpointSpec")
+    static class MockAuthenticationDetailsProvider implements BasicAuthenticationDetailsProvider {
+        private static final String DUMMY_PEM_KEY = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIBOAIBAAJAUczpZlq0T4QOr4F1RAg/lp0CJLn56ldrmis7bDQ1+XiC3/j7DzhP
+oLCd2PWHU/jniJdWAw6wESix/nb0xs/EiQIDAQABAkAqmNqyQmnDPrGnE3NNij4S
+4JBNL8vFDOEr13eKUWYKEvAAYEnscgyWQvGb7yvAQ5z/YBYatnAjakHRDO5kXtAB
+AiEAoQm2tcP3IiBm8BxstWKJlJ3xYA1euqLFdPnAaPQ5L6ECIQCCCYE0CSeLxgWw
+YqJyStqFbAzlUO1yarWIL3L61IeL6QIgenKQYxVmzKQmoVx7rFAInOCbsJV5+h/a
+VF+zVhqdgQECIEZZ3gzI5xw3hdxngHtVA+QrEM7/eXbtREjpYstRMAQBAiAy3g7Q
+ikw16ABtUnL1IVcwxBPZpSowDd5G3bcJyt+NSQ==
+-----END RSA PRIVATE KEY-----""";
+
+        @Override
+        String getKeyId() {
+            return null
+        }
+
+        @Override
+        InputStream getPrivateKey() {
+            return new ByteArrayInputStream(DUMMY_PEM_KEY.getBytes())
+        }
+
+        @Override
+        String getPassPhrase() {
+            return null
+        }
+
+        @Override
+        char[] getPassphraseCharacters() {
+            return new char[0]
         }
     }
 }

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
@@ -6,6 +6,7 @@ import com.oracle.bmc.auth.RegionProvider
 import com.oracle.bmc.monitoring.MonitoringClient
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
@@ -18,6 +19,7 @@ import spock.lang.Specification
 @Requires(bean = AuthenticationDetailsProvider)
 @Requires(bean = RegionProvider)
 @MicronautTest
+@Property(name = "spec.name", value = "OciCustomEndpointSpec")
 class OciCustomEndpointSpec extends Specification {
 
     private static final CUSTOM_ENDPOINT = "https://this-is-my-custom-endpoint.com/test"
@@ -45,6 +47,7 @@ class OciCustomEndpointSpec extends Specification {
     @Primary
     @Replaces(RegionProvider.class)
     @Bean(typed = RegionProvider.class)
+    @Requires(property = "spec.name", notEquals = "OciCustomEndpointSpec")
     static class TestRegionProvider implements RegionProvider {
 
         @Override

--- a/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
+++ b/oraclecloud-httpclient-netty/src/test/groovy/io/micronaut/oraclecloud/client/OciCustomEndpointSpec.groovy
@@ -1,56 +1,57 @@
 package io.micronaut.oraclecloud.client
 
 import com.oracle.bmc.Region
-import com.oracle.bmc.auth.AuthCachingPolicy
 import com.oracle.bmc.auth.AuthenticationDetailsProvider
 import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider
-import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider
 import com.oracle.bmc.auth.RegionProvider
 import com.oracle.bmc.monitoring.MonitoringClient
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Primary
-import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
-import io.micronaut.core.annotation.NonNull
-
+import io.micronaut.context.env.Environment
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import spock.lang.Specification
 
+
+
 @Requires(bean = AuthenticationDetailsProvider)
 @Requires(bean = RegionProvider)
-@MicronautTest
-@Property(name = "spec.name", value = "OciCustomEndpointSpec")
+@MicronautTest(startApplication = false)
 class OciCustomEndpointSpec extends Specification {
 
     private static final CUSTOM_ENDPOINT = "https://this-is-my-custom-endpoint.com/test"
 
     @Inject
-    @NonNull
-    AuthenticationDetailsProvider authenticationDetailsProvider
-
-    @Inject
     MonitoringClient.Builder client
 
     void "test get compartment"() {
+
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "spec.name"            : "OciCustomEndpointSpec",
+                "oci.config.enabled"   : "false"
+
+        ], Environment.ORACLE_CLOUD)
+
         when:
-        var client = buildClient()
+        AuthenticationDetailsProvider authenticationDetailsProvider = context.getBean(AuthenticationDetailsProvider)
+        MonitoringClient.Builder clientBuilder = context.getBean(MonitoringClient.Builder)
+        var client = clientBuilder.endpoint(CUSTOM_ENDPOINT).build(authenticationDetailsProvider)
 
         then:
+        MockAuthenticationDetailsProvider == authenticationDetailsProvider.getClass()
         client.getEndpoint() == CUSTOM_ENDPOINT
-    }
-
-    MonitoringClient buildClient() {
-        return client.endpoint(CUSTOM_ENDPOINT).build(authenticationDetailsProvider)
     }
 
     @Singleton
     @Primary
     @Replaces(RegionProvider.class)
     @Bean(typed = RegionProvider.class)
-    @Requires(property = "spec.name", notEquals = "OciCustomEndpointSpec")
+    @Requires(property = "spec.name", value = "OciCustomEndpointSpec")
     static class TestRegionProvider implements RegionProvider {
 
         @Override
@@ -60,10 +61,10 @@ class OciCustomEndpointSpec extends Specification {
     }
 
     @Singleton
-    @Replaces(ConfigFileAuthenticationDetailsProvider.class)
+    @Replaces(AuthenticationDetailsProvider.class)
     @Primary
-    @Requires(property = "spec.name", notEquals = "OciCustomEndpointSpec")
-    static class MockAuthenticationDetailsProvider implements BasicAuthenticationDetailsProvider {
+    @Requires(property = "spec.name", value = "OciCustomEndpointSpec")
+    static class MockAuthenticationDetailsProvider implements AuthenticationDetailsProvider {
         private static final String DUMMY_PEM_KEY = """
 -----BEGIN RSA PRIVATE KEY-----
 MIIBOAIBAAJAUczpZlq0T4QOr4F1RAg/lp0CJLn56ldrmis7bDQ1+XiC3/j7DzhP
@@ -93,6 +94,21 @@ ikw16ABtUnL1IVcwxBPZpSowDd5G3bcJyt+NSQ==
         @Override
         char[] getPassphraseCharacters() {
             return new char[0]
+        }
+
+        @Override
+        String getFingerprint() {
+            return null
+        }
+
+        @Override
+        String getTenantId() {
+            return null
+        }
+
+        @Override
+        String getUserId() {
+            return null
         }
     }
 }

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/MockAuthenticationDetailsProvider.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/MockAuthenticationDetailsProvider.java
@@ -1,6 +1,7 @@
 package io.micronaut.oraclecloud.httpclient.netty;
 
 import com.oracle.bmc.auth.AuthCachingPolicy;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
 import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
 import io.micronaut.context.annotation.Primary;
@@ -12,9 +13,9 @@ import java.io.InputStream;
 
 @AuthCachingPolicy(cacheKeyId = false, cachePrivateKey = false)
 @Singleton
-@Replaces(ConfigFileAuthenticationDetailsProvider.class)
+@Replaces(AuthenticationDetailsProvider.class)
 @Primary
-public class MockAuthenticationDetailsProvider implements BasicAuthenticationDetailsProvider {
+public class MockAuthenticationDetailsProvider implements AuthenticationDetailsProvider {
 
     private static final String DUMMY_PEM_KEY = """
 -----BEGIN RSA PRIVATE KEY-----
@@ -45,5 +46,20 @@ ikw16ABtUnL1IVcwxBPZpSowDd5G3bcJyt+NSQ==
     @Override
     public char[] getPassphraseCharacters() {
         return new char[0];
+    }
+
+    @Override
+    public String getFingerprint() {
+        return "";
+    }
+
+    @Override
+    public String getTenantId() {
+        return "";
+    }
+
+    @Override
+    public String getUserId() {
+        return "";
     }
 }

--- a/oraclecloud-oke-kubernetes-client/src/test/groovy/io/micronaut/oraclecloud/oke/kubernetes/client/MockKubernetesSpec.groovy
+++ b/oraclecloud-oke-kubernetes-client/src/test/groovy/io/micronaut/oraclecloud/oke/kubernetes/client/MockKubernetesSpec.groovy
@@ -4,12 +4,14 @@ import com.oracle.bmc.Region
 import com.oracle.bmc.Service
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
 import com.oracle.bmc.auth.AuthCachingPolicy
+import com.oracle.bmc.auth.AuthenticationDetailsProvider
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider
 import com.oracle.bmc.auth.RegionProvider
 import com.oracle.bmc.containerengine.ContainerEngineClient
 import com.oracle.bmc.http.signing.RequestSigner
 import com.oracle.bmc.http.signing.RequestSignerFactory
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
@@ -165,6 +167,8 @@ current-context: test-context
 
     @Singleton
     @Requires(property = 'spec.name', value = 'MockKubernetesSpec')
+    @Primary
+    @Replaces(RegionProvider.class)
     static class MockRegionProvider implements RegionProvider {
         @Override
         Region getRegion() {

--- a/oraclecloud-oke-kubernetes-client/src/test/java/io/micronaut/oraclecloud/oke/kubernetes/client/MockAuthenticationDetailsProvider.java
+++ b/oraclecloud-oke-kubernetes-client/src/test/java/io/micronaut/oraclecloud/oke/kubernetes/client/MockAuthenticationDetailsProvider.java
@@ -1,8 +1,6 @@
 package io.micronaut.oraclecloud.oke.kubernetes.client;
 
-import com.oracle.bmc.auth.AuthCachingPolicy;
-import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
-import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Replaces;
 import jakarta.inject.Singleton;
@@ -10,11 +8,10 @@ import jakarta.inject.Singleton;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-@AuthCachingPolicy(cacheKeyId = false, cachePrivateKey = false)
 @Singleton
-@Replaces(ConfigFileAuthenticationDetailsProvider.class)
+@Replaces(AuthenticationDetailsProvider.class)
 @Primary
-public class MockAuthenticationDetailsProvider implements BasicAuthenticationDetailsProvider {
+public class MockAuthenticationDetailsProvider implements AuthenticationDetailsProvider {
 
     private static final String DUMMY_PEM_KEY = """
 -----BEGIN RSA PRIVATE KEY-----
@@ -45,5 +42,20 @@ ikw16ABtUnL1IVcwxBPZpSowDd5G3bcJyt+NSQ==
     @Override
     public char[] getPassphraseCharacters() {
         return new char[0];
+    }
+
+    @Override
+    public String getFingerprint() {
+        return "";
+    }
+
+    @Override
+    public String getTenantId() {
+        return "";
+    }
+
+    @Override
+    public String getUserId() {
+        return "";
     }
 }

--- a/oraclecloud-sdk-processor/src/main/java/io/micronaut/oraclecloud/clients/processor/OracleCloudSdkProcessor.java
+++ b/oraclecloud-sdk-processor/src/main/java/io/micronaut/oraclecloud/clients/processor/OracleCloudSdkProcessor.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.oraclecloud.clients.processor;
 
+import com.oracle.bmc.auth.RegionProvider;
+import com.oracle.bmc.common.InternalBuilderAccess;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -93,7 +95,10 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
      */
     public static final String OCI_SDK_CLIENT_CLASSES_OPTION = "ociSdkClientClasses";
 
-    private static final String RETURN_BUILDER = "return clientBuilder.build(authenticationDetailsProvider)";
+    private static final String RETURN_BUILDER_STATEMENT_WITH_REGION = "return regionProvider.getRegion() != null && $T.getEndpoint(clientBuilder) == null ? clientBuilder.region(regionProvider.getRegion()).build(authenticationDetailsProvider) : clientBuilder.build(authenticationDetailsProvider)";
+
+    private static final String RETURN_BUILDER_STATEMENT_WITHOUT_REGION = "return clientBuilder.build(authenticationDetailsProvider)";
+    private static final List<String> FACTORIES_THAT_DOESNT_SUPPORT_REGION = List.of("KmsCrypto", "KmsManagement", "IdentityDomains", "Stream");
 
     private Filer filer;
     private Messager messager;
@@ -360,6 +365,7 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
         final MethodSpec.Builder constructor = buildConstructor(simpleName, builder);
         ClassName builderType = getBuilderClassNameForClient(packageName, simpleName);
         builder.addField(FieldSpec.builder(builderType, "builder", Modifier.PRIVATE).build());
+        builder.addField(FieldSpec.builder(ClassName.get(RegionProvider.class), "regionProvider", Modifier.PRIVATE).build());
         builder.addAnnotation(Factory.class);
         final ClassName authProviderType = ClassName.get("com.oracle.bmc.auth", "AbstractAuthenticationDetailsProvider");
         final AnnotationSpec.Builder requiresSpec = AnnotationSpec.builder(Requires.class)
@@ -397,12 +403,11 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
                 .addAnnotation(requiresSpec.build())
                 .addAnnotation(preDestroy.build())
                 .addModifiers(Modifier.PROTECTED)
-                .addStatement(RETURN_BUILDER);
+            .addStatement(FACTORIES_THAT_DOESNT_SUPPORT_REGION.stream().noneMatch(factoryName::startsWith) ? RETURN_BUILDER_STATEMENT_WITH_REGION : RETURN_BUILDER_STATEMENT_WITHOUT_REGION, InternalBuilderAccess.class);
         if (isBootstrapCompatible) {
             buildMethod.addAnnotation(BootstrapContextCompatible.class);
         }
         builder.addMethod(buildMethod.build());
-
 
         final JavaFile javaFile = JavaFile.builder(factoryPackageName, builder.build()).build();
         final String factoryQualifiedClassName = factoryPackageName + "." + factoryName;
@@ -440,7 +445,9 @@ public class OracleCloudSdkProcessor extends AbstractProcessor {
                                 .addAnnotation(Nullable.class).build())
                 .addCode(CodeBlock.builder()
                         .addStatement("super(" + simpleName + ".builder(), clientConfiguration, clientConfigurator, requestSignerFactory, regionProvider)")
-                        .addStatement("builder = super.getBuilder()").build());
+                        .addStatement("builder = super.getBuilder()")
+                    .addStatement("this.regionProvider = regionProvider")
+                    .build());
         builder.addModifiers(Modifier.PUBLIC, Modifier.FINAL);
         return constructor;
     }

--- a/oraclecloud-sdk-reactor/src/test/java/io/micronaut/oraclecloud/objectstorage/ObjectStorageReactorClientTest.java
+++ b/oraclecloud-sdk-reactor/src/test/java/io/micronaut/oraclecloud/objectstorage/ObjectStorageReactorClientTest.java
@@ -15,6 +15,7 @@ import com.oracle.bmc.objectstorage.requests.ListBucketsRequest;
 import com.oracle.bmc.objectstorage.responses.ListBucketsResponse;
 import com.oracle.bmc.responses.AsyncHandler;
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.oraclecloud.clients.reactor.objectstorage.ObjectStorageReactorClient;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
@@ -69,6 +70,7 @@ public class ObjectStorageReactorClientTest {
     }
 
     @AuthCachingPolicy(cacheKeyId = false, cachePrivateKey = false)
+    @Primary
     private static class MockAuth implements BasicAuthenticationDetailsProvider {
         @Override
         public String getKeyId() {

--- a/oraclecloud-sdk-rxjava2/src/test/java/io/micronaut/oraclecloud/objectstorage/ObjectStorageRxClientTest.java
+++ b/oraclecloud-sdk-rxjava2/src/test/java/io/micronaut/oraclecloud/objectstorage/ObjectStorageRxClientTest.java
@@ -5,6 +5,7 @@ import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.objectstorage.model.BucketSummary;
 import com.oracle.bmc.objectstorage.requests.ListBucketsRequest;
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.oraclecloud.clients.rxjava2.objectstorage.ObjectStorageRxClient;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
@@ -42,6 +43,7 @@ public class ObjectStorageRxClientTest {
     }
 
     @AuthCachingPolicy(cacheKeyId = false, cachePrivateKey = false)
+    @Primary
     private static class MockAuth implements BasicAuthenticationDetailsProvider {
         @Override
         public String getKeyId() {


### PR DESCRIPTION
If the endpoint is already set to the client don't use regionProvider to figure the region.

We have to move logic into the build method because in the constructor endpoint is not yet set and if the region is set the endpoint will be overwritten.
