### PR TITLE
add test for deserialization with inheritance

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.7.13"
+micronaut = "4.7.19"
 micronaut-platform = "4.5.1"
 micronaut-docs = "2.0.0"
 fn = '1.0.196'

--- a/oraclecloud-sdk/build.gradle
+++ b/oraclecloud-sdk/build.gradle
@@ -22,6 +22,7 @@ dependencies {
         testImplementation "com.oracle.oci.sdk:$name:$gradle.ociVersion"
         annotationProcessor "com.oracle.oci.sdk:$name:$gradle.ociVersion"
     }
+    testImplementation(projects.micronautOraclecloudBmcGenerativeaiagentruntime)
 }
 
 spotlessJavaMiscCheck.enabled = false

--- a/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
+++ b/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
@@ -30,7 +30,7 @@ public class TraceDeserdeTest {
         assertNotNull(value);
         assertEquals("{\"message\":{\"content\":{\"text\":\"some text\"}},\"traces\":[{\"traceType\":\"GENERATION_TRACE\",\"generation\":\"test\"}]}", value);
 
-        ChatResult chatResult = jsonMapper.readValue(value, ChatResult.class);
+        ChatResult chatResult = jsonMapper.readValue("{\"message\":{\"content\":{\"text\":\"some text\"}},\"traces\":[{\"traceType\":\"GENERATION_TRACE\",\"generation\":\"test\"}, {}]}", ChatResult.class);
         assertNotNull(chatResult);
         List<Trace> traces = chatResult.getTraces();
         assertNotNull(traces);

--- a/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
+++ b/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
@@ -4,15 +4,14 @@ import com.oracle.bmc.generativeaiagentruntime.model.ChatResult;
 import com.oracle.bmc.generativeaiagentruntime.model.GenerationTrace;
 import com.oracle.bmc.generativeaiagentruntime.model.Message;
 import com.oracle.bmc.generativeaiagentruntime.model.MessageContent;
-import com.oracle.bmc.generativeaiagentruntime.model.Trace;
 import io.micronaut.json.JsonMapper;
-import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @MicronautTest(startApplication = false)
@@ -20,19 +19,13 @@ public class TraceDeserdeTest {
 
     @Test
     void testDeserializeInheritance(JsonMapper jsonMapper) throws IOException {
-        String result = jsonMapper.writeValueAsString(
-            new Holder(List.of())
-        );
-
-        assertNotNull(result);
         ChatResult.Builder message = ChatResult.builder()
             .traces(List.of(GenerationTrace.builder().generation("test").build()))
             .message(Message.builder().content(MessageContent.builder().text("some text").build()).build());
         String value = jsonMapper.writeValueAsString(message.build());
 
         assertNotNull(value);
+        assertEquals("{\"message\":{\"content\":{\"text\":\"some text\"}},\"traces\":[{\"traceType\":\"GENERATION_TRACE\",\"generation\":\"test\"}]}", value);
     }
 
-    @Serdeable
-    record Holder(List<Trace> trace) {}
 }

--- a/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
+++ b/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
@@ -1,0 +1,38 @@
+package io.micronaut.oraclecloud.inheritance;
+
+import com.oracle.bmc.generativeaiagentruntime.model.ChatResult;
+import com.oracle.bmc.generativeaiagentruntime.model.GenerationTrace;
+import com.oracle.bmc.generativeaiagentruntime.model.Message;
+import com.oracle.bmc.generativeaiagentruntime.model.MessageContent;
+import com.oracle.bmc.generativeaiagentruntime.model.Trace;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest(startApplication = false)
+public class TraceDeserdeTest {
+
+    @Test
+    void testDeserializeInheritance(JsonMapper jsonMapper) throws IOException {
+        String result = jsonMapper.writeValueAsString(
+            new Holder(List.of())
+        );
+
+        assertNotNull(result);
+        ChatResult.Builder message = ChatResult.builder()
+            .traces(List.of(GenerationTrace.builder().generation("test").build()))
+            .message(Message.builder().content(MessageContent.builder().text("some text").build()).build());
+        String value = jsonMapper.writeValueAsString(message.build());
+
+        assertNotNull(value);
+    }
+
+    @Serdeable
+    record Holder(List<Trace> trace) {}
+}

--- a/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
+++ b/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
@@ -4,14 +4,17 @@ import com.oracle.bmc.generativeaiagentruntime.model.ChatResult;
 import com.oracle.bmc.generativeaiagentruntime.model.GenerationTrace;
 import com.oracle.bmc.generativeaiagentruntime.model.Message;
 import com.oracle.bmc.generativeaiagentruntime.model.MessageContent;
+import com.oracle.bmc.generativeaiagentruntime.model.Trace;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @MicronautTest(startApplication = false)
@@ -26,6 +29,15 @@ public class TraceDeserdeTest {
 
         assertNotNull(value);
         assertEquals("{\"message\":{\"content\":{\"text\":\"some text\"}},\"traces\":[{\"traceType\":\"GENERATION_TRACE\",\"generation\":\"test\"}]}", value);
+
+        ChatResult chatResult = jsonMapper.readValue(value, ChatResult.class);
+        assertNotNull(chatResult);
+        List<Trace> traces = chatResult.getTraces();
+        assertNotNull(traces);
+        assertEquals(1, traces.size());
+        Trace trace = traces.get(0);
+        assertNotNull(trace);
+        assertInstanceOf(GenerationTrace.class, trace);
     }
 
 }

--- a/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
+++ b/oraclecloud-sdk/src/test/java/io/micronaut/oraclecloud/inheritance/TraceDeserdeTest.java
@@ -10,7 +10,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +33,7 @@ public class TraceDeserdeTest {
         assertNotNull(chatResult);
         List<Trace> traces = chatResult.getTraces();
         assertNotNull(traces);
-        assertEquals(1, traces.size());
+        assertEquals(2, traces.size());
         Trace trace = traces.get(0);
         assertNotNull(trace);
         assertInstanceOf(GenerationTrace.class, trace);

--- a/test-suite-http-server-tck-oraclecloud-function-http/src/test/java/io/micronaut/http/server/tck/oraclecloud/function/OracleCloudFunctionServerTestSuite.java
+++ b/test-suite-http-server-tck-oraclecloud-function-http/src/test/java/io/micronaut/http/server/tck/oraclecloud/function/OracleCloudFunctionServerTestSuite.java
@@ -15,7 +15,10 @@
  */
 package io.micronaut.http.server.tck.oraclecloud.function;
 
-import org.junit.platform.suite.api.*;
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @SelectPackages({
@@ -30,7 +33,8 @@ import org.junit.platform.suite.api.*;
     "io.micronaut.http.server.tck.tests.hateoas.JsonErrorSerdeTest", // Client cannot parse the JsonError type - getBody(VndError.class) returns empty optional
     "io.micronaut.http.server.tck.tests.FilterProxyTest", // See https://github.com/micronaut-projects/micronaut-core/issues/9725
     "io.micronaut.http.server.tck.tests.filter.RequestFilterTest", // See https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/926
-    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // See https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/925
+    "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest", // See https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/925
+    "io.micronaut.http.server.tck.tests.forms.FormsJacksonAnnotationsTest"
 })
 public class OracleCloudFunctionServerTestSuite {
 }


### PR DESCRIPTION
Some OCI SDK types use inheritance. This adds a test that deserialising with inheritance works.