### PR TITLE
add defaults into retry builder

### DIFF
--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudClientConfigurationProperties.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/OracleCloudClientConfigurationProperties.java
@@ -37,20 +37,24 @@ public class OracleCloudClientConfigurationProperties {
     private final ClientConfiguration.ClientConfigurationBuilder clientBuilder = ClientConfiguration.builder();
 
     @ConfigurationBuilder(prefixes = "", value = "retry")
-    @Nullable
-    private RetryConfiguration.Builder retryBuilder;
+    private RetryConfiguration.Builder retryBuilder = new RetryConfiguration.Builder();
 
     @ConfigurationBuilder(prefixes = "", value = "circuit-breaker")
     @Nullable
     private CircuitBreakerConfiguration.CircuitBreakerConfigurationBuilder circuitBreakerBuilder;
 
+    OracleCloudClientConfigurationProperties() {
+        retryBuilder.delayStrategy(RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getDelayStrategy());
+        retryBuilder.retryCondition(RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getRetryCondition());
+        retryBuilder.terminationStrategy(RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getTerminationStrategy());
+        retryBuilder.retryOptions(RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getRetryOptions());
+    }
+
     /**
      * @return Obtains the configuration builder.
      */
     public ClientConfiguration.ClientConfigurationBuilder getClientBuilder() {
-        if (retryBuilder != null) {
-            clientBuilder.retryConfiguration(retryBuilder.build());
-        }
+        clientBuilder.retryConfiguration(retryBuilder.build());
         if (circuitBreakerBuilder != null) {
             clientBuilder.circuitBreakerConfiguration(circuitBreakerBuilder.build());
         }

--- a/oraclecloud-common/src/test/java/io/micronaut/oraclecloud/core/RetryDefaultConfigTest.java
+++ b/oraclecloud-common/src/test/java/io/micronaut/oraclecloud/core/RetryDefaultConfigTest.java
@@ -1,0 +1,26 @@
+package io.micronaut.oraclecloud.core;
+
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.retrier.RetryConfiguration;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest
+public class RetryDefaultConfigTest {
+
+    @Test
+    void testRetryDefaultConfig(
+            ClientConfiguration clientConfiguration,
+            OracleCloudCoreFactory factory) {
+        assertNotNull(clientConfiguration);
+        RetryConfiguration retryConfiguration = clientConfiguration.getRetryConfiguration();
+        assertEquals(retryConfiguration.getRetryCondition(), RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getRetryCondition());
+        assertEquals(retryConfiguration.getRetryOptions(), RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getRetryOptions());
+        assertEquals(retryConfiguration.getTerminationStrategy(), RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getTerminationStrategy());
+        assertEquals(retryConfiguration.getDelayStrategy(), RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION.getDelayStrategy());
+    }
+}

--- a/oraclecloud-common/src/test/java/io/micronaut/oraclecloud/core/RetryDefaultConfigTest.java
+++ b/oraclecloud-common/src/test/java/io/micronaut/oraclecloud/core/RetryDefaultConfigTest.java
@@ -2,7 +2,6 @@ package io.micronaut.oraclecloud.core;
 
 import com.oracle.bmc.ClientConfiguration;
 import com.oracle.bmc.retrier.RetryConfiguration;
-import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @MicronautTest
-public class RetryDefaultConfigTest {
+class RetryDefaultConfigTest {
 
     @Test
     void testRetryDefaultConfig(


### PR DESCRIPTION
Adds defaults to `RetryConfiguration.Builder` inside `OracleCloudClientConfigurationProperties`