### PR TITLE
Fix encryption SDK serde

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ oci-common = { module = 'com.oracle.oci.sdk:oci-java-sdk-common', version.ref = 
 oci-common-httpclient = { module = 'com.oracle.oci.sdk:oci-java-sdk-common-httpclient', version.ref = "oci" }
 oci-common-httpclient-jersey3 = { module = 'com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey3', version.ref = "oci" }
 oci-objectstorage = { module = 'com.oracle.oci.sdk:oci-java-sdk-objectstorage', version.ref = "oci" }
+oci-encryption = { module = 'com.oracle.oci.sdk:oci-java-sdk-encryption', version.ref = "oci" }
 oci-oke-workload-identity = { module = 'com.oracle.oci.sdk:oci-java-sdk-addons-oke-workload-identity', version.ref = "oci" }
 oci-graalvm = { module = 'com.oracle.oci.sdk:oci-java-sdk-addons-graalvm', version.ref = "oci" }
 oracle-security-oraclepki = { module = 'com.oracle.database.security:oraclepki' }

--- a/oraclecloud-httpclient-apache-http-core/build.gradle
+++ b/oraclecloud-httpclient-apache-http-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     // serde serializer
     compileOnly(mnSerde.micronaut.serde.api)
     compileOnly(libs.oci.oke.workload.identity)
+    compileOnly(libs.oci.encryption)
     testImplementation(mnSerde.micronaut.serde.api)
     testImplementation(libs.oci.oke.workload.identity)
 

--- a/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/OciSerdeConfiguration.java
+++ b/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/OciSerdeConfiguration.java
@@ -20,6 +20,8 @@ import com.oracle.bmc.auth.internal.JWK;
 import com.oracle.bmc.auth.internal.X509FederationClient;
 import com.oracle.bmc.auth.okeworkloadidentity.internal.GetOkeResourcePrincipalSessionTokenDetails;
 import com.oracle.bmc.auth.okeworkloadidentity.internal.OkeResourcePrincipalSessionToken;
+import com.oracle.bmc.encryption.internal.EncryptionHeader;
+import com.oracle.bmc.encryption.internal.EncryptionKey;
 import com.oracle.bmc.http.internal.ResponseHelper;
 import com.oracle.bmc.model.RegionSchema;
 import io.micronaut.context.annotation.Bean;
@@ -45,6 +47,8 @@ import io.micronaut.serde.config.SerdeConfiguration;
 @SerdeImport(X509FederationClient.X509FederationRequest.class)
 @SerdeImport(GetOkeResourcePrincipalSessionTokenDetails.class)
 @SerdeImport(OkeResourcePrincipalSessionToken.class)
+@SerdeImport(value = EncryptionHeader.class, deserializable = false)
+@SerdeImport(EncryptionKey.class)
 public interface OciSerdeConfiguration extends SerdeConfiguration {
     @Override
     @Bindable(defaultValue = "false")

--- a/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/serializers/EncryptionHeaderDeserializer.java
+++ b/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/serializers/EncryptionHeaderDeserializer.java
@@ -19,6 +19,7 @@ import com.oracle.bmc.encryption.internal.EncryptionHeader;
 import com.oracle.bmc.encryption.internal.EncryptionKey;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
@@ -34,6 +35,7 @@ import java.util.List;
 @Singleton
 @BootstrapContextCompatible
 @Requires(classes = EncryptionHeader.class)
+@Secondary
 final class EncryptionHeaderDeserializer implements CustomizableDeserializer<EncryptionHeader> {
 
     @Override

--- a/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/serializers/EncryptionHeaderDeserializer.java
+++ b/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/serializers/EncryptionHeaderDeserializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.httpclient.apache.core.serde.serializers;
+
+import com.oracle.bmc.encryption.internal.EncryptionHeader;
+import com.oracle.bmc.encryption.internal.EncryptionKey;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.util.CustomizableDeserializer;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Internal
+@Singleton
+@BootstrapContextCompatible
+@Requires(classes = EncryptionHeader.class)
+final class EncryptionHeaderDeserializer implements CustomizableDeserializer<EncryptionHeader> {
+
+    @Override
+    public @NonNull Deserializer<EncryptionHeader> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super EncryptionHeader> type) throws SerdeException {
+        Argument<EncryptionHeaderDto> dtoArg = Argument.of(EncryptionHeaderDto.class);
+        Deserializer<? extends EncryptionHeaderDto> dtoDeserializer = context.findDeserializer(dtoArg).createSpecific(context, dtoArg);
+        return (decoder, context1, type1) -> {
+            EncryptionHeaderDto dto = dtoDeserializer.deserialize(decoder, context1, dtoArg);
+            EncryptionHeader result = new EncryptionHeader();
+            for (EncryptionKey key : dto.encryptedDataKeys) {
+                result.setEncryptionHeader(key, dto.IV, dto.additionalAuthenticatedData);
+            }
+            return result;
+        };
+    }
+
+    @Serdeable.Deserializable
+    record EncryptionHeaderDto(
+        String additionalAuthenticatedData,
+        String IV,
+        List<EncryptionKey> encryptedDataKeys
+    ) {
+    }
+}

--- a/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
+++ b/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
@@ -7,6 +7,7 @@ import com.oracle.bmc.http.client.HttpProvider;
 import com.oracle.bmc.http.client.HttpRequest;
 import com.oracle.bmc.http.client.HttpResponse;
 import com.oracle.bmc.http.client.Method;
+import com.oracle.bmc.http.client.Serializer;
 import io.micronaut.oraclecloud.httpclient.NettyTest;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.Unpooled;
@@ -34,6 +35,11 @@ public class ApacheNettyTest extends NettyTest {
 
     HttpProvider provider() {
         return new ApacheCoreHttpProvider();
+    }
+
+    @Override
+    protected Serializer serializer() {
+        return provider().getSerializer();
     }
 
     @Override

--- a/oraclecloud-httpclient-netty/build.gradle
+++ b/oraclecloud-httpclient-netty/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation mnSerde.micronaut.serde.support
     implementation mnSerde.micronaut.serde.jackson // Includes ObjectMapper implementation
     compileOnly libs.oci.oke.workload.identity
+    compileOnly(libs.oci.encryption)
 
     testImplementation(mn.micronaut.http.server.netty)
     // for self-signed certs
@@ -43,7 +44,8 @@ dependencies {
      projects.micronautOraclecloudBmcLogging,
      projects.micronautOraclecloudBmcLoggingingestion,
      projects.micronautOraclecloudBmcLoggingsearch,
-     projects.micronautOraclecloudBmcStreaming
+     projects.micronautOraclecloudBmcStreaming,
+     projects.micronautOraclecloudBmcEncryption
     ].forEach(module -> testImplementation(module))
 }
 tasks.withType(Test).configureEach {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
@@ -49,7 +49,7 @@ import java.util.Map;
 @SerdeImport(X509FederationClient.X509FederationRequest.class)
 @SerdeImport(GetOkeResourcePrincipalSessionTokenDetails.class)
 @SerdeImport(OkeResourcePrincipalSessionToken.class)
-@SerdeImport(EncryptionHeader.class)
+@SerdeImport(value = EncryptionHeader.class, deserializable = false)
 @SerdeImport(EncryptionKey.class)
 public final class OciSdkMicronautSerializer implements Serializer {
 

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
@@ -20,6 +20,8 @@ import com.oracle.bmc.auth.internal.JWK;
 import com.oracle.bmc.auth.internal.X509FederationClient;
 import com.oracle.bmc.auth.okeworkloadidentity.internal.GetOkeResourcePrincipalSessionTokenDetails;
 import com.oracle.bmc.auth.okeworkloadidentity.internal.OkeResourcePrincipalSessionToken;
+import com.oracle.bmc.encryption.internal.EncryptionHeader;
+import com.oracle.bmc.encryption.internal.EncryptionKey;
 import com.oracle.bmc.http.client.Serializer;
 import com.oracle.bmc.http.internal.ResponseHelper;
 import com.oracle.bmc.model.RegionSchema;
@@ -47,6 +49,8 @@ import java.util.Map;
 @SerdeImport(X509FederationClient.X509FederationRequest.class)
 @SerdeImport(GetOkeResourcePrincipalSessionTokenDetails.class)
 @SerdeImport(OkeResourcePrincipalSessionToken.class)
+@SerdeImport(EncryptionHeader.class)
+@SerdeImport(EncryptionKey.class)
 public final class OciSdkMicronautSerializer implements Serializer {
 
     private final JsonMapper objectMapper;

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/EncryptionHeaderDeserializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/serializers/EncryptionHeaderDeserializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serde.serializers;
+
+import com.oracle.bmc.encryption.internal.EncryptionHeader;
+import com.oracle.bmc.encryption.internal.EncryptionKey;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.util.CustomizableDeserializer;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Internal
+@Singleton
+@BootstrapContextCompatible
+@Requires(classes = EncryptionHeader.class)
+final class EncryptionHeaderDeserializer implements CustomizableDeserializer<EncryptionHeader> {
+
+    @Override
+    public @NonNull Deserializer<EncryptionHeader> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super EncryptionHeader> type) throws SerdeException {
+        Argument<EncryptionHeaderDto> dtoArg = Argument.of(EncryptionHeaderDto.class);
+        Deserializer<? extends EncryptionHeaderDto> dtoDeserializer = context.findDeserializer(dtoArg).createSpecific(context, dtoArg);
+        return (decoder, context1, type1) -> {
+            EncryptionHeaderDto dto = dtoDeserializer.deserialize(decoder, context1, dtoArg);
+            EncryptionHeader result = new EncryptionHeader();
+            for (EncryptionKey key : dto.encryptedDataKeys) {
+                result.setEncryptionHeader(key, dto.IV, dto.additionalAuthenticatedData);
+            }
+            return result;
+        };
+    }
+
+    @Serdeable.Deserializable
+    record EncryptionHeaderDto(
+        String additionalAuthenticatedData,
+        String IV,
+        List<EncryptionKey> encryptedDataKeys
+    ) {
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/EncryptionSdkTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/EncryptionSdkTest.java
@@ -1,0 +1,131 @@
+package io.micronaut.oraclecloud.httpclient.netty;
+
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.RegionProvider;
+import com.oracle.bmc.encryption.KmsMasterKey;
+import com.oracle.bmc.encryption.KmsMasterKeyProvider;
+import com.oracle.bmc.encryption.OciCrypto;
+import com.oracle.bmc.encryption.OciCryptoInputStream;
+import com.oracle.bmc.http.client.HttpProvider;
+import com.oracle.bmc.keymanagement.KmsManagementClient;
+import com.oracle.bmc.keymanagement.KmsVaultClient;
+import com.oracle.bmc.keymanagement.model.CreateKeyDetails;
+import com.oracle.bmc.keymanagement.model.CreateVaultDetails;
+import com.oracle.bmc.keymanagement.model.Key;
+import com.oracle.bmc.keymanagement.model.KeyShape;
+import com.oracle.bmc.keymanagement.model.ScheduleVaultDeletionDetails;
+import com.oracle.bmc.keymanagement.model.Vault;
+import com.oracle.bmc.keymanagement.requests.CreateKeyRequest;
+import com.oracle.bmc.keymanagement.requests.CreateVaultRequest;
+import com.oracle.bmc.keymanagement.requests.GetVaultRequest;
+import com.oracle.bmc.keymanagement.requests.ScheduleVaultDeletionRequest;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Disabled // takes too long
+@Requires(property = "vault.secrets.compartment.ocid")
+@Requires(bean = AuthenticationDetailsProvider.class)
+@MicronautTest
+@Property(name = "use.real.auth", value = "true")
+class EncryptionSdkTest {
+    @Inject
+    KmsVaultClient kmsVaultClient;
+
+    @Inject
+    HttpProvider httpProvider;
+
+    @Inject
+    BasicAuthenticationDetailsProvider auth;
+
+    @Value("${vault.secrets.compartment.ocid}")
+    String compartmentId;
+
+    private Vault vault;
+    private KmsManagementClient kmsManagementClient;
+
+    @BeforeEach
+    void createVault() throws InterruptedException {
+        vault = kmsVaultClient.createVault(CreateVaultRequest.builder()
+            .createVaultDetails(CreateVaultDetails.builder()
+                .compartmentId(compartmentId)
+                .vaultType(CreateVaultDetails.VaultType.Default)
+                .displayName(EncryptionSdkTest.class.getName().replace('.', '_'))
+                .build())
+            .build()).getVault();
+
+        while (vault.getLifecycleState() == Vault.LifecycleState.Creating) {
+            System.out.println("Waiting for vault to be created");
+            TimeUnit.SECONDS.sleep(10);
+            vault = kmsVaultClient.getVault(GetVaultRequest.builder()
+                .vaultId(vault.getId())
+                .build()).getVault();
+        }
+
+        kmsManagementClient = KmsManagementClient.builder()
+            .vault(vault)
+            .httpProvider(httpProvider)
+            .build(auth);
+    }
+
+    @AfterEach
+    void destroyVault() {
+        if (vault != null) {
+            kmsVaultClient.scheduleVaultDeletion(ScheduleVaultDeletionRequest.builder()
+                .vaultId(vault.getId())
+                .scheduleVaultDeletionDetails(ScheduleVaultDeletionDetails.builder()
+                    .timeOfDeletion(Date.from(Instant.now().plus(8, ChronoUnit.DAYS)))
+                    .build())
+                .build());
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+        Key key = kmsManagementClient.createKey(CreateKeyRequest.builder()
+            .createKeyDetails(CreateKeyDetails.builder()
+                .displayName("test-key")
+                .compartmentId(compartmentId)
+                .protectionMode(CreateKeyDetails.ProtectionMode.Software)
+                .keyShape(KeyShape.builder()
+                    .algorithm(KeyShape.Algorithm.Aes)
+                    .length(32)
+                    .build())
+                .build())
+            .build()).getKey();
+
+        KmsMasterKey masterKey = new KmsMasterKey(
+            auth,
+            ((RegionProvider) auth).getRegion().getRegionId(),
+            vault.getId(),
+            key.getId()
+        );
+        KmsMasterKeyProvider keyProvider = new KmsMasterKeyProvider(masterKey);
+
+        OciCrypto ociCrypto = new OciCrypto();
+        OciCryptoInputStream stream = ociCrypto.createEncryptingStream(keyProvider, new ByteArrayInputStream("foo".getBytes(StandardCharsets.UTF_8)));
+        byte[] encrypted = stream.readAllBytes();
+
+        OciCryptoInputStream decryptingStream = ociCrypto.createDecryptingStream(keyProvider, new ByteArrayInputStream(encrypted));
+        byte[] decrypted = decryptingStream.readAllBytes();
+
+        assertEquals("foo", new String(decrypted, StandardCharsets.UTF_8));
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyUnmanagedTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyUnmanagedTest.java
@@ -6,6 +6,7 @@ import com.oracle.bmc.http.client.HttpClientBuilder;
 import com.oracle.bmc.http.client.HttpProvider;
 import com.oracle.bmc.http.client.HttpResponse;
 import com.oracle.bmc.http.client.Method;
+import com.oracle.bmc.http.client.Serializer;
 import io.micronaut.oraclecloud.httpclient.NettyTest;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.Unpooled;
@@ -28,6 +29,11 @@ public class NettyUnmanagedTest extends NettyTest {
 
     HttpProvider provider() {
         return PROVIDER;
+    }
+
+    @Override
+    protected Serializer serializer() {
+        return provider().getSerializer();
     }
 
     @Override

--- a/test-suite-http-client/build.gradle.kts
+++ b/test-suite-http-client/build.gradle.kts
@@ -22,7 +22,8 @@ dependencies {
         projects.micronautOraclecloudBmcLogging,
         projects.micronautOraclecloudBmcLoggingingestion,
         projects.micronautOraclecloudBmcLoggingsearch,
-        projects.micronautOraclecloudBmcStreaming
+        projects.micronautOraclecloudBmcStreaming,
+        projects.micronautOraclecloudBmcEncryption
     ).forEach { implementation(it) }
 
     testImplementation(libs.oci.common.httpclient.jersey3)

--- a/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
+++ b/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
@@ -4,11 +4,14 @@ import com.oracle.bmc.Region;
 import com.oracle.bmc.auth.SessionTokenAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import com.oracle.bmc.common.ClientBuilderBase;
+import com.oracle.bmc.encryption.internal.EncryptionHeader;
+import com.oracle.bmc.encryption.internal.EncryptionKey;
 import com.oracle.bmc.http.client.HttpClient;
 import com.oracle.bmc.http.client.HttpClientBuilder;
 import com.oracle.bmc.http.client.HttpRequest;
 import com.oracle.bmc.http.client.HttpResponse;
 import com.oracle.bmc.http.client.Method;
+import com.oracle.bmc.http.client.Serializer;
 import com.oracle.bmc.http.client.StandardClientProperties;
 import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel;
 import com.oracle.bmc.http.client.io.DuplicatableInputStream;
@@ -65,6 +68,8 @@ public abstract class NettyTest {
     public static void computeContentLength(FullHttpResponse response) {
         response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
     }
+
+    protected abstract Serializer serializer();
 
     protected abstract HttpClientBuilder newBuilder();
 
@@ -783,6 +788,22 @@ public abstract class NettyTest {
                 Assertions.assertEquals("bar", s);
             }
         }
+    }
+
+    @Test
+    public void encryptionSdk() throws IOException {
+        EncryptionHeader h = new EncryptionHeader();
+        h.setEncryptionHeader(
+            new EncryptionKey("region", "vaultId", "masterKeyId", "encryptedDataKey"),
+            "iv",
+            "additionalAuthenticatedData"
+        );
+        String json = serializer().writeValueAsString(h);
+
+        EncryptionHeader deserialized = serializer().readValue(json, EncryptionHeader.class);
+        Assertions.assertEquals(h.getEncryptionKey(), deserialized.getEncryptionKey());
+        Assertions.assertEquals(h.getIV(), deserialized.getIV());
+        Assertions.assertEquals(h.getAdditionalAuthenticatedData(), deserialized.getAdditionalAuthenticatedData());
     }
 
     @Serdeable

--- a/test-suite-http-client/src/test/java/io/micronaut/oraclecloud/httpclient/Jersey3Test.java
+++ b/test-suite-http-client/src/test/java/io/micronaut/oraclecloud/httpclient/Jersey3Test.java
@@ -3,6 +3,7 @@ package io.micronaut.oraclecloud.httpclient;
 import com.oracle.bmc.common.ClientBuilderBase;
 import com.oracle.bmc.http.client.HttpClientBuilder;
 import com.oracle.bmc.http.client.HttpProvider;
+import com.oracle.bmc.http.client.Serializer;
 import com.oracle.bmc.http.client.StandardClientProperties;
 import com.oracle.bmc.http.client.jersey3.Jersey3HttpProvider;
 import io.netty.bootstrap.ServerBootstrap;
@@ -23,6 +24,11 @@ public class Jersey3Test extends NettyTest {
     public String endpoint() {
         InetSocketAddress addr = (InetSocketAddress) getServerChannel().localAddress();
         return "http://" + addr.getHostString() + ":" + addr.getPort();
+    }
+
+    @Override
+    protected Serializer serializer() {
+        return provider().getSerializer();
     }
 
     @Override


### PR DESCRIPTION
Two tests
- A simple test for serializing and deserializing the class in question
- An end-to-end test that creates a vault and key, and does local encryption and decryption. This test is disabled because creating a vault takes multiple minutes.

I would have liked to add a local integration test but unfortunately the encryption SDK is basically untestable.