### PR TITLE
Add @SdkImport annotation to simplify importing an SDK client

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.ocisdk-metadata-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.ocisdk-metadata-module.gradle
@@ -21,6 +21,7 @@ sourceSets {
     }
 }
 
+
 if (!project.name.contains("circuitbreaker")) {
     var generateClientFactories = tasks.register("generateClientFactories", GenerateClientFactories) {
         sources = sourceSets.main.java
@@ -38,6 +39,16 @@ if (!project.name.contains("circuitbreaker")) {
         generatedCompileOnly(mnRxjava2.rxjava2)
         generatedCompileOnly(mn.reactor)
         generatedCompileOnly(mnReactor.micronaut.reactor)
+    }
+
+    tasks.named("compileGeneratedJava") {
+        options.fork = true
+        options.forkOptions.jvmArgs.add("-Doci.sdk.visitor.enabled")
+    }
+
+    tasks.named("compileJava") {
+        options.fork = true
+        options.forkOptions.jvmArgs.add("-Doci.sdk.visitor.enabled")
     }
 }
 
@@ -93,6 +104,11 @@ tasks.named("sourcesJar", Jar) {
 
 tasks.named("compileTestJava") {
     enabled = false
+}
+
+tasks.named("compileJava") {
+    options.fork = true
+    options.forkOptions.jvmArgs.add("-Doci.sdk.visitor.enabled")
 }
 
 tasks.configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ micronaut-reactor = "3.8.0"
 micronaut-rxjava2 = "2.8.0"
 micronaut-serde = "2.15.1"
 micronaut-servlet = "5.4.0"
+micronaut-sourcegen = "1.8.2"
 micronaut-sql = "6.2.1"
 micronaut-test = "4.8.1"
 micronaut-logging = "1.7.0"
@@ -54,6 +55,7 @@ micronaut-rxjava2 = { module = "io.micronaut.rxjava2:micronaut-rxjava2-bom", ver
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 micronaut-servlet = { module = "io.micronaut.servlet:micronaut-servlet-bom", version.ref = "micronaut-servlet" }
 micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
+micronaut-sourcegen = { module = "io.micronaut.sourcegen:micronaut-sourcegen-bom", version.ref = "micronaut-sourcegen" }
 micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-discovery-client = { module = "io.micronaut.discovery:micronaut-discovery-client-bom", version.ref = "micronaut-discovery-client" }
@@ -78,6 +80,7 @@ oci-common = { module = 'com.oracle.oci.sdk:oci-java-sdk-common', version.ref = 
 oci-common-httpclient = { module = 'com.oracle.oci.sdk:oci-java-sdk-common-httpclient', version.ref = "oci" }
 oci-common-httpclient-jersey3 = { module = 'com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey3', version.ref = "oci" }
 oci-objectstorage = { module = 'com.oracle.oci.sdk:oci-java-sdk-objectstorage', version.ref = "oci" }
+oci-disasterrecovery = { module = 'com.oracle.oci.sdk:oci-java-sdk-disasterrecovery', version.ref = "oci" }
 oci-encryption = { module = 'com.oracle.oci.sdk:oci-java-sdk-encryption', version.ref = "oci" }
 oci-oke-workload-identity = { module = 'com.oracle.oci.sdk:oci-java-sdk-addons-oke-workload-identity', version.ref = "oci" }
 oci-graalvm = { module = 'com.oracle.oci.sdk:oci-java-sdk-addons-graalvm', version.ref = "oci" }

--- a/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/SdkImport.java
+++ b/oraclecloud-common/src/main/java/io/micronaut/oraclecloud/core/sdk/SdkImport.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.core.sdk;
+
+/**
+ * Annotation used to import an SDK if it is generated with OCI SDK v3, but without Micronaut compatibility.
+ */
+public @interface SdkImport {
+    /**
+     * The type of the client. This should reference a type that extends from either
+     * {@link com.oracle.bmc.http.internal.BaseAsyncClient} or {@link com.oracle.bmc.http.internal.BaseSyncClient}.
+     *
+     * @return The type of a client to import.
+     */
+    Class<?> value();
+}

--- a/oraclecloud-httpclient-netty/build.gradle
+++ b/oraclecloud-httpclient-netty/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     testAnnotationProcessor mn.micronaut.inject.java
     testAnnotationProcessor projects.micronautOraclecloudSerdeProcessor
+    testAnnotationProcessor(mnSourcegen.micronaut.sourcegen.generator.java)
     testCompileOnly mn.micronaut.jackson.databind
     testRuntimeOnly mn.micronaut.runtime
 
@@ -35,7 +36,7 @@ dependencies {
     testImplementation mn.micronaut.context
     testImplementation projects.micronautOraclecloudCommon
     testImplementation projects.testSuiteHttpClient
-
+    testImplementation(libs.oci.disasterrecovery)
     [projects.micronautOraclecloudBmcMonitoring,
      projects.micronautOraclecloudBmcIdentity,
      projects.micronautOraclecloudBmcObjectstorage,
@@ -52,3 +53,5 @@ dependencies {
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
+//compileTestJava.options.fork = true
+//compileTestJava.options.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/oraclecloud-httpclient-netty/build.gradle
+++ b/oraclecloud-httpclient-netty/build.gradle
@@ -36,7 +36,9 @@ dependencies {
     testImplementation mn.micronaut.context
     testImplementation projects.micronautOraclecloudCommon
     testImplementation projects.testSuiteHttpClient
-    testImplementation(libs.oci.disasterrecovery)
+    testImplementation(libs.oci.disasterrecovery) {
+        exclude(group: "com.oracle.oci.sdk", module: "oci-java-sdk-common")
+    }
     [projects.micronautOraclecloudBmcMonitoring,
      projects.micronautOraclecloudBmcIdentity,
      projects.micronautOraclecloudBmcObjectstorage,
@@ -53,5 +55,3 @@ dependencies {
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
-//compileTestJava.options.fork = true
-//compileTestJava.options.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/SdkImportTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/SdkImportTest.java
@@ -1,0 +1,72 @@
+package io.micronaut.oraclecloud.httpclient.netty;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.RegionProvider;
+import com.oracle.bmc.disasterrecovery.DisasterRecoveryClient;
+import com.oracle.bmc.disasterrecovery.model.CreateDrPlanDetails;
+import com.oracle.bmc.disasterrecovery.model.DrPlan;
+import com.oracle.bmc.disasterrecovery.model.DrPlanType;
+import com.oracle.bmc.disasterrecovery.requests.CreateDrPlanRequest;
+import com.oracle.bmc.disasterrecovery.responses.CreateDrPlanResponse;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.oraclecloud.core.sdk.SdkImport;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@SdkImport(DisasterRecoveryClient.class)
+@MicronautTest
+@Property(name = "oci.config.path", value = "") // Disable reading config file
+public class SdkImportTest {
+
+    @Inject
+    DisasterRecoveryClient disasterRecoveryClient;
+
+    @Test
+    void testImport() {
+        Assertions.assertNotNull(disasterRecoveryClient);
+        CreateDrPlanResponse drPlan = disasterRecoveryClient.createDrPlan(
+            CreateDrPlanRequest.builder()
+                .body$(CreateDrPlanDetails.builder()
+                    .type(DrPlanType.Failover)
+                    .drProtectionGroupId("mygroup")
+                    .sourcePlanId("myplan")
+                    .build())
+                .build()
+        );
+        DrPlan dp = drPlan.getDrPlan();
+        Assertions.assertNotNull(dp);
+        Assertions.assertEquals(DrPlanType.Failover, drPlan.getDrPlan().getType());
+    }
+
+    @MockBean(RegionProvider.class)
+    RegionProvider mockRegionProvider() {
+        return () -> Region.AF_JOHANNESBURG_1;
+    }
+
+    @MockBean
+    BeanCreatedEventListener<DisasterRecoveryClient.Builder> setEndpoint(EmbeddedServer embeddedServer) {
+        return event -> event.getBean().endpoint("http://localhost:" + embeddedServer.getPort());
+    }
+
+    @MockBean
+    @Controller
+    static class TestController {
+        @Post("/20220125/drPlans")
+        HttpResponse<DrPlan> createDrPlan(@Body CreateDrPlanDetails createDrPlanRequest) {
+            return HttpResponse.created(DrPlan.builder()
+                    .sourcePlanId(createDrPlanRequest.getSourcePlanId())
+                    .drProtectionGroupId(createDrPlanRequest.getDrProtectionGroupId())
+                    .type(createDrPlanRequest.getType())
+                .build());
+        }
+    }
+}

--- a/oraclecloud-serde-processor/build.gradle
+++ b/oraclecloud-serde-processor/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     testImplementation(libs.oci.objectstorage)
     testImplementation mn.micronaut.inject.java.test
     testImplementation(mnSourcegen.micronaut.sourcegen.generator.java)
+    testImplementation(projects.micronautOraclecloudCommon)
 }

--- a/oraclecloud-serde-processor/build.gradle
+++ b/oraclecloud-serde-processor/build.gradle
@@ -1,15 +1,25 @@
 plugins {
     id 'io.micronaut.build.internal.common'
-    id 'io.micronaut.build.internal.oraclecloud-base'
+    id 'io.micronaut.build.internal.oraclecloud-module'
 }
 
 dependencies {
     // Transitive dependencies
     implementation mn.micronaut.inject
     implementation mn.micronaut.inject.java
+    implementation(projects.micronautOraclecloudCommon) {
+        transitive = false
+    }
+    implementation(libs.oci.common) {
+        transitive = false
+    }
+    implementation mnSourcegen.micronaut.sourcegen.annotations
+    implementation mnSourcegen.micronaut.sourcegen.generator
     implementation mnSerde.micronaut.serde.processor
     implementation mnSerde.micronaut.serde.api
 
+    testImplementation(libs.oci.objectstorage)
     testImplementation mn.micronaut.inject.java.test
+    testImplementation(mnSourcegen.micronaut.sourcegen.generator.java)
     testImplementation libs.oci.common
 }

--- a/oraclecloud-serde-processor/build.gradle
+++ b/oraclecloud-serde-processor/build.gradle
@@ -17,3 +17,7 @@ dependencies {
     testImplementation(mnSourcegen.micronaut.sourcegen.generator.java)
     testImplementation(projects.micronautOraclecloudCommon)
 }
+
+micronautBuild {
+    binaryCompatibility.enabled = false
+}

--- a/oraclecloud-serde-processor/build.gradle
+++ b/oraclecloud-serde-processor/build.gradle
@@ -7,12 +7,6 @@ dependencies {
     // Transitive dependencies
     implementation mn.micronaut.inject
     implementation mn.micronaut.inject.java
-    implementation(projects.micronautOraclecloudCommon) {
-        transitive = false
-    }
-    implementation(libs.oci.common) {
-        transitive = false
-    }
     implementation mnSourcegen.micronaut.sourcegen.annotations
     implementation mnSourcegen.micronaut.sourcegen.generator
     implementation mnSerde.micronaut.serde.processor
@@ -21,5 +15,4 @@ dependencies {
     testImplementation(libs.oci.objectstorage)
     testImplementation mn.micronaut.inject.java.test
     testImplementation(mnSourcegen.micronaut.sourcegen.generator.java)
-    testImplementation libs.oci.common
 }

--- a/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/OciSdkModelSerdeVisitor.java
+++ b/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/OciSdkModelSerdeVisitor.java
@@ -20,7 +20,6 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.Element;
@@ -32,11 +31,8 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 
-import javax.annotation.processing.SupportedOptions;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Type element visitor vising oci sdk models and enums.
@@ -50,17 +46,14 @@ import java.util.Set;
  * @since 2.3.2
  */
 @Internal
-@SupportedOptions(OciSdkModelSerdeVisitor.ENABLED)
 public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Object> {
     private static final String OCI_SDK_MODEL_CLASS_NAME = "com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel";
     private static final String OCI_SDK_ENUM_CLASS_NAME = "com.oracle.bmc.http.internal.BmcEnum";
     private static final String OCI_SDK_ENUM_CREATOR_NAME = "create";
     private static final String INTROSPECTION_PACKAGE = ".introspection";
-    public static final String ENABLED = "oci.sdk.visitor.enabled";
 
     private boolean visitingOciSdkModel;
     private boolean visitingOciSdkEnum;
-    private boolean enabled = false;
 
     @Override
     public int getOrder() {
@@ -74,22 +67,7 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
     }
 
     @Override
-    public Set<String> getSupportedOptions() {
-        return Set.of(ENABLED);
-    }
-
-    @Override
-    public void start(VisitorContext visitorContext) {
-        Map<String, String> options = visitorContext.getOptions();
-        String sysProp = System.getProperty(ENABLED);
-        this.enabled = options.containsKey(ENABLED) || sysProp != null;
-    }
-
-    @Override
     public void visitClass(ClassElement element, VisitorContext context) {
-        if (!enabled) {
-            return;
-        }
         visitingOciSdkModel = isOciSdkModel(element);
         visitingOciSdkEnum = isOciSdkEnum(element);
 
@@ -108,9 +86,6 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
 
     @Override
     public void visitField(FieldElement element, VisitorContext context) {
-        if (!enabled) {
-            return;
-        }
         if (visitingOciSdkModel) {
             makeElementNullable(element);
         }
@@ -118,9 +93,6 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
 
     @Override
     public void visitConstructor(ConstructorElement element, VisitorContext context) {
-        if (!enabled) {
-            return;
-        }
         if (visitingOciSdkModel) {
             makeParametersNullable(element);
         }
@@ -128,9 +100,6 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
 
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
-        if (!enabled) {
-            return;
-        }
         if (visitingOciSdkEnum && element.getName().equals(OCI_SDK_ENUM_CREATOR_NAME)) {
             makeParametersNullable(element);
         }

--- a/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/OciSdkModelSerdeVisitor.java
+++ b/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/OciSdkModelSerdeVisitor.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.Element;
@@ -31,8 +32,11 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 
+import javax.annotation.processing.SupportedOptions;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Type element visitor vising oci sdk models and enums.
@@ -46,14 +50,17 @@ import java.util.Optional;
  * @since 2.3.2
  */
 @Internal
+@SupportedOptions(OciSdkModelSerdeVisitor.ENABLED)
 public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Object> {
     private static final String OCI_SDK_MODEL_CLASS_NAME = "com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel";
     private static final String OCI_SDK_ENUM_CLASS_NAME = "com.oracle.bmc.http.internal.BmcEnum";
     private static final String OCI_SDK_ENUM_CREATOR_NAME = "create";
     private static final String INTROSPECTION_PACKAGE = ".introspection";
+    public static final String ENABLED = "oci.sdk.visitor.enabled";
 
     private boolean visitingOciSdkModel;
     private boolean visitingOciSdkEnum;
+    private boolean enabled = false;
 
     @Override
     public int getOrder() {
@@ -67,7 +74,22 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
     }
 
     @Override
+    public Set<String> getSupportedOptions() {
+        return Set.of(ENABLED);
+    }
+
+    @Override
+    public void start(VisitorContext visitorContext) {
+        Map<String, String> options = visitorContext.getOptions();
+        String sysProp = System.getProperty(ENABLED);
+        this.enabled = options.containsKey(ENABLED) || sysProp != null;
+    }
+
+    @Override
     public void visitClass(ClassElement element, VisitorContext context) {
+        if (!enabled) {
+            return;
+        }
         visitingOciSdkModel = isOciSdkModel(element);
         visitingOciSdkEnum = isOciSdkEnum(element);
 
@@ -86,6 +108,9 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
 
     @Override
     public void visitField(FieldElement element, VisitorContext context) {
+        if (!enabled) {
+            return;
+        }
         if (visitingOciSdkModel) {
             makeElementNullable(element);
         }
@@ -93,6 +118,9 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
 
     @Override
     public void visitConstructor(ConstructorElement element, VisitorContext context) {
+        if (!enabled) {
+            return;
+        }
         if (visitingOciSdkModel) {
             makeParametersNullable(element);
         }
@@ -100,6 +128,9 @@ public class OciSdkModelSerdeVisitor implements TypeElementVisitor<Object, Objec
 
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
+        if (!enabled) {
+            return;
+        }
         if (visitingOciSdkEnum && element.getName().equals(OCI_SDK_ENUM_CREATOR_NAME)) {
             makeParametersNullable(element);
         }

--- a/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/SdkImportVisitor.java
+++ b/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/SdkImportVisitor.java
@@ -15,15 +15,6 @@
  */
 package io.micronaut.oraclecloud.httpclient.netty.visitor;
 
-import com.oracle.bmc.ClientConfiguration;
-import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
-import com.oracle.bmc.auth.RegionProvider;
-import com.oracle.bmc.common.InternalBuilderAccess;
-import com.oracle.bmc.http.ClientConfigurator;
-import com.oracle.bmc.http.internal.BaseAsyncClient;
-import com.oracle.bmc.http.internal.BaseSyncClient;
-import com.oracle.bmc.http.signing.RequestSignerFactory;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
@@ -36,8 +27,6 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.visitor.TypeElementQuery;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
-import io.micronaut.oraclecloud.core.sdk.AbstractSdkClientFactory;
-import io.micronaut.oraclecloud.core.sdk.SdkImport;
 import io.micronaut.serde.annotation.SerdeImport;
 import io.micronaut.sourcegen.generator.SourceGenerator;
 import io.micronaut.sourcegen.generator.SourceGenerators;
@@ -60,9 +49,24 @@ import java.util.Locale;
 import java.util.Set;
 
 /**
- * Visitor that handles the {@link SdkImport} annotation.
+ * Visitor that handles the {@code io.micronaut.oraclecloud.core.sdk.SdkImport} annotation.
+ *
+ * @since 5.3.0
  */
-public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
+public class SdkImportVisitor implements TypeElementVisitor<Object, Object> {
+
+    public static final String ANN_SDK_IMPORT = "io.micronaut.oraclecloud.core.sdk.SdkImport";
+    public static final ClassTypeDef FACTORY_TYPE = ClassTypeDef.of("io.micronaut.oraclecloud.core.sdk.AbstractSdkClientFactory");
+    public static final ClassTypeDef TYPE_AUTH_DETAILS_PROVIDER = ClassTypeDef.of("com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider");
+    public static final TypeDef TYPE_REGION_PROVIDER = TypeDef.of("com.oracle.bmc.auth.RegionProvider");
+    public static final ClassTypeDef TYPE_CLIENT_CONFIGURATION = ClassTypeDef.of("com.oracle.bmc.ClientConfiguration");
+    public static final ClassTypeDef TYPE_CLIENT_CONFIGURATOR = ClassTypeDef.of("com.oracle.bmc.http.ClientConfigurator");
+    public static final ClassTypeDef TYPE_REQUEST_SIGNER_FACTORY = ClassTypeDef.of("com.oracle.bmc.http.signing.RequestSignerFactory");
+    public static final ClassTypeDef TYPE_REGION = ClassTypeDef.of("com.oracle.bmc.Region");
+    public static final ClassTypeDef TYPE_INTERNAL_BUILDER_ACCESS = ClassTypeDef.of("com.oracle.bmc.common.InternalBuilderAccess");
+    private ClassElement asyncClientType;
+    private ClassElement syncClientType;
+
     @Override
     public @NonNull VisitorKind getVisitorKind() {
         return VisitorKind.ISOLATING;
@@ -75,17 +79,23 @@ public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
 
     @Override
     public Set<String> getSupportedAnnotationNames() {
-        return Set.of(SdkImport.class.getName());
+        return Set.of(ANN_SDK_IMPORT);
+    }
+
+    @Override
+    public void start(VisitorContext visitorContext) {
+        this.asyncClientType = visitorContext.getClassElement("com.oracle.bmc.http.internal.BaseAsyncClient").orElse(null);
+        this.syncClientType = visitorContext.getClassElement("com.oracle.bmc.http.internal.BaseSyncClient").orElse(null);
     }
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
-        AnnotationValue<SdkImport> importAnn = element.getAnnotation(SdkImport.class);
-        if (importAnn != null) {
+        AnnotationValue<?> importAnn = element.getAnnotation(ANN_SDK_IMPORT);
+        if (importAnn != null && asyncClientType != null && syncClientType != null) {
             AnnotationClassValue<?> acv = importAnn.annotationClassValue(AnnotationMetadata.VALUE_MEMBER).orElse(null);
             if (acv != null) {
                 context.getClassElement(acv.getName()).ifPresent(classElement -> {
-                    if (classElement.isAssignable(BaseAsyncClient.class) || classElement.isAssignable(BaseSyncClient.class)) {
+                    if (classElement.isAssignable(asyncClientType) || classElement.isAssignable(syncClientType)) {
                         generateClientFactory(element, classElement, context);
                     }
                 });
@@ -99,14 +109,16 @@ public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
         VisitorContext context) {
 
         ClassElement clientBuilder = context.getClassElement(clientElement.getName() + ".Builder").orElse(null);
-        if (clientBuilder != null) {
+        if (clientBuilder == null) {
+            context.fail("Unable to import SDK, client has no Builder: " + clientElement.getName(), originatingElement);
+        } else {
             ClassTypeDef clientBuilderDef = ClassTypeDef.of(clientBuilder);
             ClassTypeDef clientDef = ClassTypeDef.of(clientElement);
 
             // generate factory type for client that extends from AbstractSdkClientFactory
             AnnotationDef requiresAnn = AnnotationDef.builder(Requires.class)
                 .addMember("classes", clientDef)
-                .addMember("beans", ClassTypeDef.of(AbstractAuthenticationDetailsProvider.class))
+                .addMember("beans", TYPE_AUTH_DETAILS_PROVIDER)
                 .build();
             String simpleName = clientElement.getSimpleName();
             String serviceId = resolveServiceId(simpleName);
@@ -119,10 +131,10 @@ public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
                 .addAnnotation(AnnotationDef.builder(SerdeImport.class)
                     .addMember("packageName", clientElement.getPackageName() + ".model")
                     .build())
-                .superclass(TypeDef.parameterized(ClassTypeDef.of(AbstractSdkClientFactory.class), clientBuilderDef, clientDef));
+                .superclass(TypeDef.parameterized(FACTORY_TYPE, clientBuilderDef, clientDef));
 
             // RegionProvider field
-            FieldDef regionProviderField = FieldDef.builder("regionProvider", TypeDef.of(RegionProvider.class))
+            FieldDef regionProviderField = FieldDef.builder("regionProvider", TYPE_REGION_PROVIDER)
                 .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                 .build();
             builder.addField(regionProviderField);
@@ -131,26 +143,26 @@ public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
             builder.addMethod(MethodDef.constructor()
                 .addModifiers(Modifier.PROTECTED)
                     .addParameters(List.of(
-                        ParameterDef.builder("clientConfiguration", TypeDef.of(ClientConfiguration.class)).build(),
-                        ParameterDef.builder("specificClientConfiguration", TypeDef.of(ClientConfiguration.class))
+                        ParameterDef.builder("clientConfiguration", TYPE_CLIENT_CONFIGURATION).build(),
+                        ParameterDef.builder("specificClientConfiguration", TYPE_CLIENT_CONFIGURATION)
                             .addAnnotation(Nullable.class)
                             .addAnnotation(AnnotationDef.builder(Named.class)
                                 .addMember(AnnotationMetadata.VALUE_MEMBER, serviceId)
                                 .build())
                             .build(),
-                        ParameterDef.builder("serviceIdClientConfigurator", TypeDef.of(ClientConfigurator.class))
+                        ParameterDef.builder("serviceIdClientConfigurator", TYPE_CLIENT_CONFIGURATOR)
                             .addAnnotation(Nullable.class)
                             .addAnnotation(AnnotationDef.builder(Named.class)
                                 .addMember(AnnotationMetadata.VALUE_MEMBER, serviceId)
                                 .build())
                             .build(),
-                        ParameterDef.builder("clientConfigurator", TypeDef.of(ClientConfigurator.class))
+                        ParameterDef.builder("clientConfigurator", TYPE_CLIENT_CONFIGURATOR)
                             .addAnnotation(Nullable.class)
                             .build(),
-                        ParameterDef.builder("requestSignerFactory", TypeDef.of(RequestSignerFactory.class))
+                        ParameterDef.builder("requestSignerFactory", TYPE_REQUEST_SIGNER_FACTORY)
                             .addAnnotation(Nullable.class)
                             .build(),
-                        ParameterDef.builder("regionProvider", TypeDef.of(RegionProvider.class))
+                        ParameterDef.builder("regionProvider", TYPE_REGION_PROVIDER)
                             .addAnnotation(Nullable.class)
                             .build())
                     )
@@ -188,7 +200,7 @@ public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
                     .returns(clientDef)
                     .addParameters(
                         clientBuilderDef,
-                        TypeDef.of(AbstractAuthenticationDetailsProvider.class)
+                        TYPE_AUTH_DETAILS_PROVIDER
                     )
                     .addModifiers(Modifier.PROTECTED)
                     .addAnnotation(Singleton.class)
@@ -201,16 +213,16 @@ public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
                         VariableDef.MethodParameter authDetails = params.get(1);
                         VariableDef.Field field = aThis.field(regionProviderField);
                         ExpressionDef.ConditionExpressionDef condition = field.isNonNull().and(
-                            field.invoke("getRegion", TypeDef.of(Region.class)).isNonNull()
+                            field.invoke("getRegion", TYPE_REGION).isNonNull()
                         ).and(
-                            ClassTypeDef.of(InternalBuilderAccess.class)
+                            TYPE_INTERNAL_BUILDER_ACCESS
                                 .invokeStatic("getEndpoint", ClassTypeDef.STRING, clientBuilderParam)
                                 .isNull()
                         );
 
 
                         return condition.ifTrue(
-                            clientBuilderParam.invoke("region", clientBuilderDef, field.invoke("getRegion", TypeDef.of(Region.class)))
+                            clientBuilderParam.invoke("region", clientBuilderDef, field.invoke("getRegion", TYPE_REGION))
                                 .invoke("build", clientDef, authDetails).returning(),
                             clientBuilderParam.invoke("build", clientDef, authDetails).returning()
                         );

--- a/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/SdkImportVisitor.java
+++ b/oraclecloud-serde-processor/src/main/java/io/micronaut/oraclecloud/httpclient/netty/visitor/SdkImportVisitor.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.httpclient.netty.visitor;
+
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.RegionProvider;
+import com.oracle.bmc.common.InternalBuilderAccess;
+import com.oracle.bmc.http.ClientConfigurator;
+import com.oracle.bmc.http.internal.BaseAsyncClient;
+import com.oracle.bmc.http.internal.BaseSyncClient;
+import com.oracle.bmc.http.signing.RequestSignerFactory;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementQuery;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.oraclecloud.core.sdk.AbstractSdkClientFactory;
+import io.micronaut.oraclecloud.core.sdk.SdkImport;
+import io.micronaut.serde.annotation.SerdeImport;
+import io.micronaut.sourcegen.generator.SourceGenerator;
+import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.FieldDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.ParameterDef;
+import io.micronaut.sourcegen.model.StatementDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import io.micronaut.sourcegen.model.VariableDef;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import javax.lang.model.element.Modifier;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Visitor that handles the {@link SdkImport} annotation.
+ */
+public class SdkImportVisitor implements TypeElementVisitor<SdkImport, Object> {
+    @Override
+    public @NonNull VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public TypeElementQuery query() {
+        return TypeElementQuery.onlyClass();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(SdkImport.class.getName());
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        AnnotationValue<SdkImport> importAnn = element.getAnnotation(SdkImport.class);
+        if (importAnn != null) {
+            AnnotationClassValue<?> acv = importAnn.annotationClassValue(AnnotationMetadata.VALUE_MEMBER).orElse(null);
+            if (acv != null) {
+                context.getClassElement(acv.getName()).ifPresent(classElement -> {
+                    if (classElement.isAssignable(BaseAsyncClient.class) || classElement.isAssignable(BaseSyncClient.class)) {
+                        generateClientFactory(element, classElement, context);
+                    }
+                });
+            }
+        }
+    }
+
+    private void generateClientFactory(
+        ClassElement originatingElement,
+        ClassElement clientElement,
+        VisitorContext context) {
+
+        ClassElement clientBuilder = context.getClassElement(clientElement.getName() + ".Builder").orElse(null);
+        if (clientBuilder != null) {
+            ClassTypeDef clientBuilderDef = ClassTypeDef.of(clientBuilder);
+            ClassTypeDef clientDef = ClassTypeDef.of(clientElement);
+
+            // generate factory type for client that extends from AbstractSdkClientFactory
+            AnnotationDef requiresAnn = AnnotationDef.builder(Requires.class)
+                .addMember("classes", clientDef)
+                .addMember("beans", ClassTypeDef.of(AbstractAuthenticationDetailsProvider.class))
+                .build();
+            String simpleName = clientElement.getSimpleName();
+            String serviceId = resolveServiceId(simpleName);
+            String typeName = originatingElement.getPackageName() + "." + simpleName + "Factory";
+            ClassDef.ClassDefBuilder builder = ClassDef
+                .builder(typeName)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addAnnotation(Factory.class)
+                .addAnnotation(requiresAnn)
+                .addAnnotation(AnnotationDef.builder(SerdeImport.class)
+                    .addMember("packageName", clientElement.getPackageName() + ".model")
+                    .build())
+                .superclass(TypeDef.parameterized(ClassTypeDef.of(AbstractSdkClientFactory.class), clientBuilderDef, clientDef));
+
+            // RegionProvider field
+            FieldDef regionProviderField = FieldDef.builder("regionProvider", TypeDef.of(RegionProvider.class))
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build();
+            builder.addField(regionProviderField);
+
+            // generate constructor
+            builder.addMethod(MethodDef.constructor()
+                .addModifiers(Modifier.PROTECTED)
+                    .addParameters(List.of(
+                        ParameterDef.builder("clientConfiguration", TypeDef.of(ClientConfiguration.class)).build(),
+                        ParameterDef.builder("specificClientConfiguration", TypeDef.of(ClientConfiguration.class))
+                            .addAnnotation(Nullable.class)
+                            .addAnnotation(AnnotationDef.builder(Named.class)
+                                .addMember(AnnotationMetadata.VALUE_MEMBER, serviceId)
+                                .build())
+                            .build(),
+                        ParameterDef.builder("serviceIdClientConfigurator", TypeDef.of(ClientConfigurator.class))
+                            .addAnnotation(Nullable.class)
+                            .addAnnotation(AnnotationDef.builder(Named.class)
+                                .addMember(AnnotationMetadata.VALUE_MEMBER, serviceId)
+                                .build())
+                            .build(),
+                        ParameterDef.builder("clientConfigurator", TypeDef.of(ClientConfigurator.class))
+                            .addAnnotation(Nullable.class)
+                            .build(),
+                        ParameterDef.builder("requestSignerFactory", TypeDef.of(RequestSignerFactory.class))
+                            .addAnnotation(Nullable.class)
+                            .build(),
+                        ParameterDef.builder("regionProvider", TypeDef.of(RegionProvider.class))
+                            .addAnnotation(Nullable.class)
+                            .build())
+                    )
+                .build((aThis, methodParameters) -> {
+                        VariableDef.MethodParameter regionProvider = methodParameters.get(5);
+                        return StatementDef.multi(
+                            aThis.superRef().invokeConstructor(
+                                clientDef.invokeStatic("builder", clientBuilderDef),
+                                methodParameters.get(0),
+                                methodParameters.get(1),
+                                methodParameters.get(2),
+                                methodParameters.get(3),
+                                methodParameters.get(4)),
+                            aThis.field(regionProviderField).assign(regionProvider)
+                        );
+                    }
+                ));
+
+
+            // generate builder method
+            builder.addMethod(
+                MethodDef.builder("getBuilder")
+                    .returns(clientBuilderDef)
+                    .addModifiers(Modifier.PROTECTED)
+                    .addAnnotation(Singleton.class)
+                    .addAnnotation(requiresAnn)
+                    .build((aThis, params) ->
+                        aThis.superRef().invoke("getBuilder", clientBuilderDef).returning()
+                    )
+            );
+
+            // generate build method
+            builder.addMethod(
+                MethodDef.builder("build")
+                    .returns(clientDef)
+                    .addParameters(
+                        clientBuilderDef,
+                        TypeDef.of(AbstractAuthenticationDetailsProvider.class)
+                    )
+                    .addModifiers(Modifier.PROTECTED)
+                    .addAnnotation(Singleton.class)
+                    .addAnnotation(requiresAnn)
+                    .addAnnotation(AnnotationDef.builder(Bean.class)
+                        .addMember("preDestroy", "close")
+                        .build())
+                    .build((aThis, params) -> {
+                        VariableDef.MethodParameter clientBuilderParam = params.get(0);
+                        VariableDef.MethodParameter authDetails = params.get(1);
+                        VariableDef.Field field = aThis.field(regionProviderField);
+                        ExpressionDef.ConditionExpressionDef condition = field.isNonNull().and(
+                            field.invoke("getRegion", TypeDef.of(Region.class)).isNonNull()
+                        ).and(
+                            ClassTypeDef.of(InternalBuilderAccess.class)
+                                .invokeStatic("getEndpoint", ClassTypeDef.STRING, clientBuilderParam)
+                                .isNull()
+                        );
+
+
+                        return condition.ifTrue(
+                            clientBuilderParam.invoke("region", clientBuilderDef, field.invoke("getRegion", TypeDef.of(Region.class)))
+                                .invoke("build", clientDef, authDetails).returning(),
+                            clientBuilderParam.invoke("build", clientDef, authDetails).returning()
+                        );
+                        }
+                    )
+            );
+
+            // write class
+            ClassDef factoryDef = builder.build();
+            SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);
+            if (sourceGenerator != null) {
+                sourceGenerator.write(factoryDef, context, originatingElement);
+            } else {
+                context.fail("Cannot process @SdkImport(). Missing SourceGenerator module from annotation processor path (for example micronaut-sourcegen-generator-java for Java).", originatingElement);
+            }
+        }
+    }
+
+    private static String resolveServiceId(String simpleName) {
+        String serviceId;
+        if (simpleName.endsWith("AsyncClient")) {
+            serviceId = simpleName.substring(0, simpleName.length() - "AsyncClient".length()).toLowerCase(Locale.ENGLISH);
+        } else if (simpleName.endsWith("Client")) {
+            serviceId = simpleName.substring(0, simpleName.length() - "Client".length()).toLowerCase(Locale.ENGLISH);
+        } else {
+            serviceId = simpleName.toLowerCase(Locale.ENGLISH);
+        }
+        return serviceId;
+    }
+}

--- a/oraclecloud-serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/oraclecloud-serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -1,1 +1,2 @@
 io.micronaut.oraclecloud.httpclient.netty.visitor.OciSdkModelSerdeVisitor
+io.micronaut.oraclecloud.httpclient.netty.visitor.SdkImportVisitor

--- a/oraclecloud-serde-processor/src/test/groovy/io/micronaut/oraclecloud/httpclient/netty/visitor/SdkImportVisitorSpec.groovy
+++ b/oraclecloud-serde-processor/src/test/groovy/io/micronaut/oraclecloud/httpclient/netty/visitor/SdkImportVisitorSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.oraclecloud.httpclient.netty.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.serde.annotation.SerdeImport
+
+class SdkImportVisitorSpec extends AbstractTypeElementSpec {
+
+    void "test generate OCI SDK factory"() {
+        given:
+        def definition = buildBeanDefinition("test.ObjectStorageClientFactory", """
+package test;
+
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+import io.micronaut.oraclecloud.core.sdk.SdkImport;
+
+@SdkImport(ObjectStorageClient.class)
+class Test {}
+""")
+
+        expect:
+        definition != null
+        definition.stringValue(SerdeImport, "packageName").get() == 'com.oracle.bmc.objectstorage.model'
+        // check introspections are generated
+        definition.beanType.classLoader.loadClass('test.$com_oracle_bmc_objectstorage_model_ReencryptObjectDetails$Introspection')
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,6 +66,7 @@ configure<io.micronaut.build.MicronautBuildSettingsExtension> {
     importMicronautCatalog("micronaut-rxjava2")
     importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-servlet")
+    importMicronautCatalog("micronaut-sourcegen")
     importMicronautCatalog("micronaut-sql")
     importMicronautCatalog("micronaut-validation")
     importMicronautCatalog("micronaut-discovery-client")

--- a/src/main/docs/guide/httpclient.adoc
+++ b/src/main/docs/guide/httpclient.adoc
@@ -1,4 +1,4 @@
-This module provides a netty client implementation for the Java OCI SDK. The client uses link:https://micronaut-projects.github.io/micronaut-serialization/latest/guide/[Micronaut Serialization].
+This module provides a Netty client implementation for the Java OCI SDK. The client uses link:https://micronaut-projects.github.io/micronaut-serialization/latest/guide/[Micronaut Serialization].
 
 Add a dependency to the `micronaut-oraclecloud-httpclient-netty` module:
 
@@ -7,6 +7,22 @@ dependency:io.micronaut.oraclecloud:micronaut-oraclecloud-httpclient-netty[]
 For serialization to work correctly, use one of the micronaut OCI SDK modules instead of the OCI SDK modules. For example, for Object Store define the dependency:
 
 dependency:io.micronaut.oraclecloud:micronaut-oraclecloud-bmc-objectstorage[]
+
+### Importing SDK's not compiled with Micronaut
+
+If an OCI SDK client exists that is built with OCI SDK v3 or above but not compiled with Micronaut and therefore missing the the required Micronaut Serialization types you can import the sdk use the `@SdkImport` annotation.
+
+First you should add an annotation processor dependency:
+
+dependency:io.micronaut.oraclecloud:oraclecloud-serde-processor[scope="annotationProcessor"]
+
+Then declare `@SdkImport` on any class passing the type of the client you wish to import. For example:
+
+.Declaring `@SdkImport`
+[source,java]
+----
+@SdkImport(DisasterRecoveryClient.class)
+----
 
 ### Migrate
 


### PR DESCRIPTION
Adds a new `@SdkImport` annotation that lets the user easily import an SDK client built with SDK v3 but not compiled with Micronaut.