### PR TITLE
fix empty description in oracle cloud metrics

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -16,17 +16,21 @@
 package io.micronaut.oraclecloud.monitoring;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micronaut.configuration.metrics.micrometer.ExportConfigurationProperties;
 import io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.ShutdownEvent;
+import io.micronaut.core.annotation.Order;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.oraclecloud.core.TenancyIdProvider;
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudConfig;
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudMeterRegistry;
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudRawMeterRegistry;
 import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.event.annotation.EventListener;
 import jakarta.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +54,8 @@ public class OracleCloudMeterRegistryFactory {
     public static final String ORACLECLOUD_METRICS_ENABLED = ORACLECLOUD_METRICS_CONFIG + ".enabled";
     public static final String ORACLECLOUD_RAW_METRICS_ENABLED = ORACLECLOUD_METRICS_CONFIG + ".raw.enabled";
 
+    public static final int SHUTDOWN_ORDER = -100;
+    private MeterRegistry meterRegistry;
     private final TenancyIdProvider tenancyIdProvider;
     private final ApplicationConfiguration applicationConfiguration;
 
@@ -105,7 +111,8 @@ public class OracleCloudMeterRegistryFactory {
     @Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_RAW_METRICS_ENABLED, notEquals = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
     OracleCloudMeterRegistry oracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig,
                                                       Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
-        return new OracleCloudMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
+        meterRegistry =  new OracleCloudMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
+        return (OracleCloudMeterRegistry) meterRegistry;
     }
 
     /**
@@ -113,7 +120,6 @@ public class OracleCloudMeterRegistryFactory {
      * the oraclecloudmonitoring is enabled and raw metrics enabled.
      * Will be false by default when this configuration is included in project.
      *
-     * @param httpClientRegistry the http client registry
      * @param oracleCloudConfig the OracleCloudConfig configuration
      * @param monitoringIngestionClientProvider  the monitoring ingestion client provider
      * @return the registry
@@ -123,6 +129,23 @@ public class OracleCloudMeterRegistryFactory {
     @Requires(property = MeterRegistryFactory.MICRONAUT_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
     @Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_RAW_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.FALSE)
     OracleCloudRawMeterRegistry oracleCloudRawMeterRegistry(OracleCloudConfig oracleCloudConfig, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider) {
-        return new OracleCloudRawMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
+        meterRegistry = new OracleCloudRawMeterRegistry(oracleCloudConfig, Clock.SYSTEM, monitoringIngestionClientProvider);
+        return (OracleCloudRawMeterRegistry) meterRegistry;
     }
+
+    /**
+     * Shutdown the meter registry if it wasn't already shutdown.
+     * @param event The shutdown event.
+     */
+    @EventListener
+    @Order(SHUTDOWN_ORDER)
+    void onShutdown(ShutdownEvent event) {
+        if (meterRegistry != null && !meterRegistry.isClosed()) {
+            LOG.info("Shutting down micrometer meter registry and flushing metrics buffer.");
+            meterRegistry.close();
+            meterRegistry = null;
+            LOG.info("Micrometer meter registry shutdown complete.");
+        }
+    }
+
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -114,7 +114,9 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
                     .postMetricDataDetails(builder.build())
                     .build());
 
-                postMetricDataResponse.getPostMetricDataResponseDetails().getFailedMetrics().forEach( metrics -> logger.debug("Metric refused: {}", metrics.getMetricData()));
+                if (logger.isDebugEnabled() && !postMetricDataResponse.getPostMetricDataResponseDetails().getFailedMetrics().isEmpty()) {
+                    postMetricDataResponse.getPostMetricDataResponseDetails().getFailedMetrics().forEach( metrics -> logger.debug("Metric refused: {}", metrics.getMetricData()));
+                }
 
             } catch (Exception e) {
                 logger.error("failed to post metrics to oracle cloud infrastructure monitoring: {}", e.getMessage(), e);

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -18,6 +18,7 @@ package io.micronaut.oraclecloud.monitoring.micrometer;
 import com.oracle.bmc.monitoring.model.MetricDataDetails;
 import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
 import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
+import com.oracle.bmc.monitoring.responses.PostMetricDataResponse;
 import com.oracle.bmc.util.internal.StringUtils;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
@@ -109,9 +110,12 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
                     monitoringIngestionClient = monitoringIngestionClientProvider.get();
                 }
 
-                monitoringIngestionClient.postMetricData(PostMetricDataRequest.builder()
+                PostMetricDataResponse postMetricDataResponse = monitoringIngestionClient.postMetricData(PostMetricDataRequest.builder()
                     .postMetricDataDetails(builder.build())
                     .build());
+
+                postMetricDataResponse.getPostMetricDataResponseDetails().getFailedMetrics().forEach( metrics -> logger.debug("Metric refused: {}", metrics.getMetricData()));
+
             } catch (Exception e) {
                 logger.error("failed to post metrics to oracle cloud infrastructure monitoring: {}", e.getMessage(), e);
             }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRegistry.java
@@ -215,7 +215,8 @@ public class OracleCloudMeterRegistry extends AbstractOracleCloudMeterRegistry {
                 .name(getMetricName(id, suffix))
                 .namespace(oracleCloudConfig.namespace())
                 .resourceGroup(oracleCloudConfig.resourceGroup())
-                .metadata(oracleCloudConfig.description() && id.getDescription() != null
+                .metadata(oracleCloudConfig.description()
+                    && id.getDescription() != null  && !id.getDescription().isBlank()
                         ? Collections.singletonMap("description", id.getDescription()) : null)
                 .datapoints(Collections.singletonList(
                         Datapoint.builder()

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -232,7 +232,8 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
             .name(getMetricName(id, suffix))
             .namespace(oracleCloudConfig.namespace())
             .resourceGroup(oracleCloudConfig.resourceGroup())
-            .metadata(oracleCloudConfig.description() && id.getDescription() != null
+            .metadata(oracleCloudConfig.description() &&
+                id.getDescription() != null && !id.getDescription().isBlank()
                 ? Map.of("description", id.getDescription()) : null)
             .datapoints(datapoints)
             .dimensions(toDimensions(id.getConventionTags(config().namingConvention())))

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactoryTest.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactoryTest.groovy
@@ -5,6 +5,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
+import io.micronaut.context.event.ShutdownEvent
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudConfig
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudMeterRegistry
 import io.micronaut.oraclecloud.monitoring.micrometer.OracleCloudRawMeterRegistry
@@ -107,6 +108,45 @@ class OracleCloudMeterRegistryFactoryTest extends Specification {
         OracleCloudConfig oracleCloudConfig = context.getBean(OracleCloudConfig)
         oracleCloudConfig.enabled()
 
+        cleanup:
+        context.close()
+    }
+
+    def "test shutdown oracle cloud metrics registry"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "micronaut.metrics.export.oraclecloud.namespace"      : "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.applicationName": "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.enabled"        : "true",
+        ], Environment.ORACLE_CLOUD)
+
+        expect:
+        context.containsBean(OracleCloudMeterRegistry)
+        OracleCloudMeterRegistryFactory oracleCloudMeterRegistryFactory = context.getBean(OracleCloudMeterRegistryFactory)
+        OracleCloudMeterRegistry oracleCloudMeterRegistry = context.getBean(OracleCloudMeterRegistry)
+        !oracleCloudMeterRegistry.isClosed()
+        oracleCloudMeterRegistryFactory.onShutdown(new ShutdownEvent(context))
+        oracleCloudMeterRegistry.isClosed()
+        cleanup:
+        context.close()
+    }
+
+    def "test shutdown oracle cloud raw metrics registry"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "micronaut.metrics.export.oraclecloud.namespace"      : "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.applicationName": "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.enabled"        : "false",
+                "micronaut.metrics.export.oraclecloud.raw.enabled"    : "true",
+        ], Environment.ORACLE_CLOUD)
+
+        expect:
+        context.containsBean(OracleCloudRawMeterRegistry)
+        OracleCloudMeterRegistryFactory oracleCloudMeterRegistryFactory = context.getBean(OracleCloudMeterRegistryFactory)
+        OracleCloudRawMeterRegistry oracleCloudRawMeterRegistry = context.getBean(OracleCloudRawMeterRegistry)
+        !oracleCloudRawMeterRegistry.isClosed()
+        oracleCloudMeterRegistryFactory.onShutdown(new ShutdownEvent(context))
+        oracleCloudRawMeterRegistry.isClosed()
         cleanup:
         context.close()
     }

--- a/oraclecloud-micrometer/src/test/resources/logback.xml
+++ b/oraclecloud-micrometer/src/test/resources/logback.xml
@@ -6,6 +6,8 @@
         </encoder>
     </appender>
 
+    <logger name="io.micronaut.oraclecloud.monitoring.micrometer.AbstractOracleCloudMeterRegistry" level="DEBUG"/>
+
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
The oracle cloud monitoring service doesn't allow empty description