### PR TITLE
Sign requests before buffering

### DIFF
--- a/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
+++ b/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
@@ -106,6 +106,12 @@ public class ApacheNettyTest extends NettyTest {
         super.fullSetupConnectionDiesMidError();
     }
 
+    @Override
+    @Disabled // not implemented
+    public void functionsClientTest() throws CertificateException {
+        super.functionsClientTest();
+    }
+
     @Test
     public void location() throws Exception {
         netty.handleOneRequest((ctx, request) -> {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/MicronautHttpRequest.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/MicronautHttpRequest.java
@@ -278,6 +278,13 @@ final class MicronautHttpRequest implements HttpRequest {
 
     @Override
     public CompletionStage<HttpResponse> execute() {
+        for (RequestInterceptor interceptor : client.requestInterceptors) {
+            interceptor.intercept(this);
+        }
+        return execute0();
+    }
+
+    private CompletionStage<HttpResponse> execute0() {
         // jersey client buffers even when BUFFER_REQUEST is off, if the content length is not explicitly set.
         if (byteBody != null && !(byteBody instanceof AvailableByteBody) && (client.buffered || byteBody.expectedLength().isEmpty()) && !expectContinue) {
 
@@ -285,12 +292,8 @@ final class MicronautHttpRequest implements HttpRequest {
             return byteBody.buffer()
                 .thenCompose(v -> {
                     this.byteBody = v;
-                    return execute();
+                    return execute0();
                 });
-        }
-
-        for (RequestInterceptor interceptor : client.requestInterceptors) {
-            interceptor.intercept(this);
         }
 
         finalizeRequest();

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/LegacyNettyManagedTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/LegacyNettyManagedTest.java
@@ -28,4 +28,10 @@ public class LegacyNettyManagedTest extends NettyManagedTest {
     public void fullSetupErrorParseFailure() throws CertificateException {
         super.fullSetupErrorParseFailure();
     }
+
+    @Override
+    @Disabled // behavior change not done in legacy client
+    public void functionsClientTest() throws CertificateException {
+        super.functionsClientTest();
+    }
 }

--- a/test-suite-http-client/build.gradle.kts
+++ b/test-suite-http-client/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
         projects.micronautOraclecloudBmcLoggingingestion,
         projects.micronautOraclecloudBmcLoggingsearch,
         projects.micronautOraclecloudBmcStreaming,
+        projects.micronautOraclecloudBmcFunctions,
         projects.micronautOraclecloudBmcEncryption
     ).forEach { implementation(it) }
 

--- a/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
+++ b/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
@@ -6,6 +6,8 @@ import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
 import com.oracle.bmc.common.ClientBuilderBase;
 import com.oracle.bmc.encryption.internal.EncryptionHeader;
 import com.oracle.bmc.encryption.internal.EncryptionKey;
+import com.oracle.bmc.functions.FunctionsInvokeClient;
+import com.oracle.bmc.functions.requests.InvokeFunctionRequest;
 import com.oracle.bmc.http.client.HttpClient;
 import com.oracle.bmc.http.client.HttpClientBuilder;
 import com.oracle.bmc.http.client.HttpRequest;
@@ -16,6 +18,7 @@ import com.oracle.bmc.http.client.StandardClientProperties;
 import com.oracle.bmc.http.client.internal.ExplicitlySetBmcModel;
 import com.oracle.bmc.http.client.io.DuplicatableInputStream;
 import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.io.internal.KeepOpenInputStream;
 import com.oracle.bmc.model.BmcException;
 import com.oracle.bmc.monitoring.MonitoringClient;
 import com.oracle.bmc.monitoring.model.CreateAlarmDetails;
@@ -29,6 +32,7 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.serde.annotation.SerdeImport;
 import io.micronaut.serde.annotation.Serdeable;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -67,6 +71,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -645,6 +650,57 @@ public abstract class NettyTest {
                     .alarmId("foo")
                     .build());
             }
+        }
+    }
+
+    @Test
+    public void functionsClientTest() throws CertificateException {
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        byte[] body = new byte[10];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        netty.handleOneRequest((ctx, request) -> {
+            Assertions.assertEquals(HttpMethod.POST, request.method());
+            Assertions.assertEquals("/20181201/functions/function-id/actions/invoke", request.uri());
+            Assertions.assertTrue(request.headers().get(HttpHeaderNames.AUTHORIZATION).contains("content-length"));
+
+            SignatureV1.verify((FullHttpRequest) request, ssc.cert().getPublicKey());
+
+            Assertions.assertArrayEquals(body, ByteBufUtil.getBytes(((FullHttpRequest) request).content()));
+
+            DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("{}", StandardCharsets.UTF_8)
+            );
+            response.headers().add("Content-Type", "application/json");
+            computeContentLength(response);
+            ctx.writeAndFlush(response);
+        });
+
+        FunctionsInvokeClient.Builder builder = FunctionsInvokeClient.builder();
+        customize(builder);
+        try (FunctionsInvokeClient invokeClient = builder
+            .build(SimpleAuthenticationDetailsProvider.builder()
+                .tenantId("tenantId")
+                .userId("userId")
+                .fingerprint("fingerprint")
+                .passPhrase("")
+                .region(Region.US_PHOENIX_1)
+                .privateKeySupplier(() -> {
+                    try {
+                        return new FileInputStream(ssc.privateKey());
+                    } catch (FileNotFoundException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
+                .build())) {
+
+            invokeClient.invokeFunction(InvokeFunctionRequest.builder()
+                .functionId("function-id")
+                .fnIntent(InvokeFunctionRequest.FnIntent.Httprequest)
+                .fnInvokeType(InvokeFunctionRequest.FnInvokeType.Sync)
+                .invokeFunctionBody(new KeepOpenInputStream(new ByteArrayInputStream(body)))
+                .build());
         }
     }
 

--- a/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/SignatureV1.java
+++ b/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/SignatureV1.java
@@ -1,0 +1,75 @@
+package io.micronaut.oraclecloud.httpclient;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+class SignatureV1 {
+    public static void verify(FullHttpRequest request, PublicKey publicKey) {
+        if (request.headers().getAll("Authorization").size() != 1) {
+            throw new IllegalArgumentException("Missing or too many Authorization headers");
+        }
+        Map<String, String> authorization = parseAuthorizationHeader(request.headers().get("Authorization"));
+        if (!authorization.get("version").equals("1")) {
+            throw new IllegalArgumentException("Unsupported version");
+        }
+        String[] headers = authorization.get("headers").split(" ");
+        StringBuilder signingString = new StringBuilder();
+        for (String header : headers) {
+            if (header.equals("(request-target)")) {
+                signingString.append(header).append(": ")
+                        .append(request.method().name().toLowerCase(Locale.ROOT)).append(' ').append(request.uri())
+                        .append("\n");
+            } else {
+                signingString.append(header).append(": ").append(request.headers().get(header)).append("\n");
+            }
+        }
+        // remove trailing \n
+        signingString.setLength(signingString.length() - 1);
+        if (!authorization.get("algorithm").equals("rsa-sha256")) {
+            throw new IllegalArgumentException("Unsupported algorithm");
+        }
+        if (publicKey == null) {
+            // null means no verification, we just check the basic format.
+            return;
+        }
+        try {
+            Signature signature = Signature.getInstance("SHA256withRSA");
+            signature.initVerify(publicKey);
+            signature.update(signingString.toString().getBytes(StandardCharsets.UTF_8));
+            if (!signature.verify(Base64.getDecoder().decode(authorization.get("signature")))) {
+                throw new IllegalArgumentException("Signature failed to verify");
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError(e);
+        } catch (InvalidKeyException | SignatureException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static Map<String, String> parseAuthorizationHeader(String header) {
+        if (!header.startsWith("Signature ")) {
+            throw new IllegalArgumentException("Not a signature header");
+        }
+        header = header.substring("Signature ".length());
+        Map<String, String> result = new HashMap<>();
+        for (String s : header.split(",\\s*")) {
+            String[] parts = s.split("=", 2);
+            if (!parts[1].startsWith("\"") || !parts[1].endsWith("\"")) {
+                throw new IllegalArgumentException("Invalid header");
+            }
+            String value = parts[1].substring(1, parts[1].length() - 1);
+            result.put(parts[0], value);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Buffering the request may consume the InputStream, making it unusable for RequestSignerImpl. Move RequestInterceptor processing (incl RequestSigner) before the buffering step.