### PR TITLE
fix: do not instantiate OracleCloudMeterRegistryFactory when metrics …

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -47,6 +47,8 @@ import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory
  * @since 1.2
  */
 @Factory
+@Requires(property = MeterRegistryFactory.MICRONAUT_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
+@Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 public class OracleCloudMeterRegistryFactory {
 
     public static final Logger LOG = LoggerFactory.getLogger(OracleCloudMeterRegistryFactory.class);


### PR DESCRIPTION
when:
micronaut.metrics.enabled=false
micronaut.metrics.export.oraclecloud.enabled=false
```

The application throws a `DependencyInjectionException` at shutdown:
```
Failed to inject value for parameter [tenancyIdProvider] of class: OracleCloudMeterRegistryFactory
Message: Invalid Oracle Cloud Configuration. If you are running locally ensure the CLI is configured by running: oci setup config…are disabled