### PR TITLE
fix: do not instantiate OracleCloudMeterRegistryFactory when metrics disabled

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -48,7 +48,6 @@ import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory
  */
 @Factory
 @Requires(property = MeterRegistryFactory.MICRONAUT_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
-@Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 public class OracleCloudMeterRegistryFactory {
 
     public static final Logger LOG = LoggerFactory.getLogger(OracleCloudMeterRegistryFactory.class);

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactory.java
@@ -47,6 +47,8 @@ import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory
  * @since 1.2
  */
 @Factory
+@Requires(property = MeterRegistryFactory.MICRONAUT_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
+@Requires(property = OracleCloudMeterRegistryFactory.ORACLECLOUD_METRICS_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 public class OracleCloudMeterRegistryFactory {
 
     public static final Logger LOG = LoggerFactory.getLogger(OracleCloudMeterRegistryFactory.class);

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactoryTest.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/OracleCloudMeterRegistryFactoryTest.groovy
@@ -75,6 +75,23 @@ class OracleCloudMeterRegistryFactoryTest extends Specification {
         context.close()
     }
 
+    def "factory is NOT present when both global and oraclecloud metrics are disabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "micronaut.metrics.export.oraclecloud.namespace"      : "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.applicationName": "micronaut_test",
+                "micronaut.metrics.export.oraclecloud.enabled"        : "false",
+                "micronaut.metrics.enabled"                           : "false",
+        ], Environment.ORACLE_CLOUD)
+
+        expect:
+        !context.containsBean(OracleCloudMeterRegistryFactory)  // factory must NOT exist
+
+        cleanup:
+        context.close()
+
+    }
+
     def "test raw metrics meter registry loads when both are true"() {
         given:
         ApplicationContext context = ApplicationContext.run([


### PR DESCRIPTION
when:
```
micronaut.metrics.enabled=false
micronaut.metrics.export.oraclecloud.enabled=false
```


The application throws a `DependencyInjectionException` at shutdown:
Failed to inject value for parameter [tenancyIdProvider] of class: OracleCloudMeterRegistryFactory
Message: Invalid Oracle Cloud Configuration. If you are running locally ensure the CLI is configured by running: oci setup config…are disabled