### PR TITLE
Add ATP datasource regression tests for omitted wallet password

### DIFF
--- a/oraclecloud-atp-hikari-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/hikari/HikariPoolConfigurationListenerSpec.groovy
+++ b/oraclecloud-atp-hikari-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/hikari/HikariPoolConfigurationListenerSpec.groovy
@@ -18,7 +18,6 @@ import java.sql.Connection
 import java.sql.ResultSet
 import java.util.Optional
 
-@Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
 class HikariPoolConfigurationListenerSpec extends Specification {
 
     @Shared
@@ -30,6 +29,7 @@ class HikariPoolConfigurationListenerSpec extends Specification {
     @Shared
     String atpId = System.getenv("ATP_OCID")
 
+    @Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
     void "test it connects to database"() {
         given:
         ApplicationContext context = ApplicationContext.run([
@@ -52,6 +52,7 @@ class HikariPoolConfigurationListenerSpec extends Specification {
         context.close()
     }
 
+    @Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
     void "test it skips datasource without ocid field"() {
         given:
         ApplicationContext context = ApplicationContext.run([

--- a/oraclecloud-atp-hikari-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/hikari/HikariPoolConfigurationListenerSpec.groovy
+++ b/oraclecloud-atp-hikari-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/hikari/HikariPoolConfigurationListenerSpec.groovy
@@ -1,7 +1,14 @@
 package io.micronaut.oraclecloud.atp.jdbc.hikari
 
+import io.micronaut.configuration.jdbc.hikari.DatasourceConfiguration
+import io.micronaut.context.BeanLocator
+import io.micronaut.context.event.BeanInitializingEvent
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
+import io.micronaut.oraclecloud.atp.jdbc.AutonomousDatabaseConfiguration
+import io.micronaut.oraclecloud.atp.jdbc.OracleWalletArchiveProvider
+import io.micronaut.oraclecloud.atp.wallet.datasource.CanConfigureOracleDataSource
+import oracle.jdbc.datasource.impl.OracleDataSource
 import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Specification
@@ -9,6 +16,7 @@ import spock.lang.Specification
 import javax.sql.DataSource
 import java.sql.Connection
 import java.sql.ResultSet
+import java.util.Optional
 
 @Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
 class HikariPoolConfigurationListenerSpec extends Specification {
@@ -63,5 +71,33 @@ class HikariPoolConfigurationListenerSpec extends Specification {
 
         cleanup:
         context.close()
+    }
+
+    void "test it configures datasource when wallet password is omitted"() {
+        given:
+        BeanLocator beanLocator = Mock()
+        OracleWalletArchiveProvider walletArchiveProvider = Mock()
+        CanConfigureOracleDataSource walletArchive = Stub() {
+            configure(_ as OracleDataSource) >> { OracleDataSource dataSource ->
+                dataSource.setURL("jdbc:oracle:thin:@db_high?TNS_ADMIN=/tmp/wallet")
+            }
+        }
+        HikariPoolConfigurationListener listener = new HikariPoolConfigurationListener(walletArchiveProvider, beanLocator)
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration("default")
+        AutonomousDatabaseConfiguration autonomousDatabaseConfiguration = new AutonomousDatabaseConfiguration()
+        autonomousDatabaseConfiguration.setOcid("ocid1.autonomousdatabase.oc1..example")
+        BeanInitializingEvent<DatasourceConfiguration> event = Stub() {
+            getBean() >> datasourceConfiguration
+        }
+
+        beanLocator.findBean(AutonomousDatabaseConfiguration, _) >> Optional.of(autonomousDatabaseConfiguration)
+
+        when:
+        listener.onInitialized(event)
+
+        then:
+        1 * walletArchiveProvider.loadWalletArchive(autonomousDatabaseConfiguration) >> walletArchive
+        datasourceConfiguration.getUrl() == "jdbc:oracle:thin:@db_high?TNS_ADMIN=/tmp/wallet"
+        datasourceConfiguration.getDriverClassName() == HikariPoolConfigurationListener.ORACLE_JDBC_ORACLE_DRIVER
     }
 }

--- a/oraclecloud-atp-ucp-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListenerSpec.groovy
+++ b/oraclecloud-atp-ucp-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListenerSpec.groovy
@@ -83,29 +83,41 @@ class UcpPoolConfigurationListenerSpec extends Specification {
 
     void "test it configures datasource when wallet password is omitted"() {
         given:
+        String walletUrl = "jdbc:oracle:thin:@db_high?TNS_ADMIN=/tmp/wallet"
         BeanLocator beanLocator = Mock()
         OracleWalletArchiveProvider walletArchiveProvider = Mock()
-        CanConfigureOracleDataSource walletArchive = Stub() {
-            configure(_ as OracleDataSourceAttributes) >> { OracleDataSourceAttributes attributes ->
-                attributes.url("jdbc:oracle:thin:@db_high?TNS_ADMIN=/tmp/wallet")
-            }
-        }
-        UcpPoolConfigurationListener listener = new UcpPoolConfigurationListener(walletArchiveProvider, beanLocator)
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration("default", Mock(Environment))
-        AutonomousDatabaseConfiguration autonomousDatabaseConfiguration = new AutonomousDatabaseConfiguration()
-        autonomousDatabaseConfiguration.setOcid("ocid1.autonomousdatabase.oc1..example")
-        BeanInitializingEvent<DatasourceConfiguration> event = Stub() {
-            getBean() >> datasourceConfiguration
-        }
+        AutonomousDatabaseConfiguration autonomousDatabaseConfiguration = autonomousDatabaseConfiguration()
 
         beanLocator.findBean(AutonomousDatabaseConfiguration, _) >> Optional.of(autonomousDatabaseConfiguration)
 
         when:
-        listener.onInitialized(event)
+        new UcpPoolConfigurationListener(walletArchiveProvider, beanLocator)
+                .onInitialized(initializing(datasourceConfiguration))
 
         then:
-        1 * walletArchiveProvider.loadWalletArchive(autonomousDatabaseConfiguration) >> walletArchive
-        datasourceConfiguration.getUrl() == "jdbc:oracle:thin:@db_high?TNS_ADMIN=/tmp/wallet"
+        1 * walletArchiveProvider.loadWalletArchive(autonomousDatabaseConfiguration) >> walletArchiveWithUrl(walletUrl)
+        datasourceConfiguration.getUrl() == walletUrl
         datasourceConfiguration.getConfiguredDriverClassName() == UcpPoolConfigurationListener.ORACLE_JDBC_POOL_ORACLE_DATA_SOURCE
+    }
+
+    private CanConfigureOracleDataSource walletArchiveWithUrl(String walletUrl) {
+        Stub(CanConfigureOracleDataSource) {
+            configure(_ as OracleDataSourceAttributes) >> { OracleDataSourceAttributes attributes ->
+                attributes.url(walletUrl)
+            }
+        }
+    }
+
+    private static AutonomousDatabaseConfiguration autonomousDatabaseConfiguration() {
+        AutonomousDatabaseConfiguration configuration = new AutonomousDatabaseConfiguration()
+        configuration.setOcid("ocid1.autonomousdatabase.oc1..example")
+        configuration
+    }
+
+    private BeanInitializingEvent<DatasourceConfiguration> initializing(DatasourceConfiguration datasourceConfiguration) {
+        Stub(BeanInitializingEvent) {
+            getBean() >> datasourceConfiguration
+        }
     }
 }

--- a/oraclecloud-atp-ucp-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListenerSpec.groovy
+++ b/oraclecloud-atp-ucp-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListenerSpec.groovy
@@ -20,7 +20,6 @@ import java.sql.Connection
 import java.sql.ResultSet
 import java.util.Optional
 
-@Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
 class UcpPoolConfigurationListenerSpec extends Specification {
 
     @Shared
@@ -32,6 +31,7 @@ class UcpPoolConfigurationListenerSpec extends Specification {
     @Shared
     String atpId = System.getenv("ATP_OCID")
 
+    @Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
     void "test it connects to database"() {
         given:
         ApplicationContext context = ApplicationContext.run([
@@ -55,6 +55,7 @@ class UcpPoolConfigurationListenerSpec extends Specification {
     }
 
     @PendingFeature(reason = "Requires CI config?")
+    @Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
     void "test it skips datasource without ocid field"() {
         given:
         ApplicationContext context = ApplicationContext.run([
@@ -90,7 +91,7 @@ class UcpPoolConfigurationListenerSpec extends Specification {
             }
         }
         UcpPoolConfigurationListener listener = new UcpPoolConfigurationListener(walletArchiveProvider, beanLocator)
-        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration("default")
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration("default", Mock(Environment))
         AutonomousDatabaseConfiguration autonomousDatabaseConfiguration = new AutonomousDatabaseConfiguration()
         autonomousDatabaseConfiguration.setOcid("ocid1.autonomousdatabase.oc1..example")
         BeanInitializingEvent<DatasourceConfiguration> event = Stub() {

--- a/oraclecloud-atp-ucp-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListenerSpec.groovy
+++ b/oraclecloud-atp-ucp-test/src/test/groovy/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListenerSpec.groovy
@@ -1,7 +1,14 @@
 package io.micronaut.oraclecloud.atp.jdbc.ucp
 
+import io.micronaut.configuration.jdbc.ucp.DatasourceConfiguration
+import io.micronaut.context.BeanLocator
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.event.BeanInitializingEvent
 import io.micronaut.context.env.Environment
+import io.micronaut.oraclecloud.atp.jdbc.AutonomousDatabaseConfiguration
+import io.micronaut.oraclecloud.atp.jdbc.OracleWalletArchiveProvider
+import io.micronaut.oraclecloud.atp.wallet.datasource.CanConfigureOracleDataSource
+import io.micronaut.oraclecloud.atp.wallet.datasource.OracleDataSourceAttributes
 import oracle.ucp.jdbc.PoolDataSource
 import spock.lang.PendingFeature
 import spock.lang.Requires
@@ -11,6 +18,7 @@ import spock.lang.Specification
 import javax.sql.DataSource
 import java.sql.Connection
 import java.sql.ResultSet
+import java.util.Optional
 
 @Requires({ System.getenv("ATP_USER") && System.getenv("ATP_PASS") && System.getenv("ATP_OCID") })
 class UcpPoolConfigurationListenerSpec extends Specification {
@@ -70,5 +78,33 @@ class UcpPoolConfigurationListenerSpec extends Specification {
 
         cleanup:
         context.close()
+    }
+
+    void "test it configures datasource when wallet password is omitted"() {
+        given:
+        BeanLocator beanLocator = Mock()
+        OracleWalletArchiveProvider walletArchiveProvider = Mock()
+        CanConfigureOracleDataSource walletArchive = Stub() {
+            configure(_ as OracleDataSourceAttributes) >> { OracleDataSourceAttributes attributes ->
+                attributes.url("jdbc:oracle:thin:@db_high?TNS_ADMIN=/tmp/wallet")
+            }
+        }
+        UcpPoolConfigurationListener listener = new UcpPoolConfigurationListener(walletArchiveProvider, beanLocator)
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration("default")
+        AutonomousDatabaseConfiguration autonomousDatabaseConfiguration = new AutonomousDatabaseConfiguration()
+        autonomousDatabaseConfiguration.setOcid("ocid1.autonomousdatabase.oc1..example")
+        BeanInitializingEvent<DatasourceConfiguration> event = Stub() {
+            getBean() >> datasourceConfiguration
+        }
+
+        beanLocator.findBean(AutonomousDatabaseConfiguration, _) >> Optional.of(autonomousDatabaseConfiguration)
+
+        when:
+        listener.onInitialized(event)
+
+        then:
+        1 * walletArchiveProvider.loadWalletArchive(autonomousDatabaseConfiguration) >> walletArchive
+        datasourceConfiguration.getUrl() == "jdbc:oracle:thin:@db_high?TNS_ADMIN=/tmp/wallet"
+        datasourceConfiguration.getConfiguredDriverClassName() == UcpPoolConfigurationListener.ORACLE_JDBC_POOL_ORACLE_DATA_SOURCE
     }
 }

--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProvider.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProvider.java
@@ -76,8 +76,11 @@ public class OracleWalletArchiveProvider {
      * @return wallet archive
      */
     public CanConfigureOracleDataSource loadWalletArchive(AutonomousDatabaseConfiguration autonomousDatabaseConfiguration) {
-        GenerateAutonomousDatabaseWalletDetails.Builder builder = GenerateAutonomousDatabaseWalletDetails.builder()
-                .password(autonomousDatabaseConfiguration.getWalletPassword());
+        GenerateAutonomousDatabaseWalletDetails.Builder builder = GenerateAutonomousDatabaseWalletDetails.builder();
+
+        if (autonomousDatabaseConfiguration.getWalletPassword() != null) {
+            builder.password(autonomousDatabaseConfiguration.getWalletPassword());
+        }
 
         if (autonomousDatabaseConfiguration.getWalletType() != null) {
             builder.generateType(autonomousDatabaseConfiguration.getWalletType());

--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProvider.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProvider.java
@@ -78,7 +78,7 @@ public class OracleWalletArchiveProvider {
     public CanConfigureOracleDataSource loadWalletArchive(AutonomousDatabaseConfiguration autonomousDatabaseConfiguration) {
         GenerateAutonomousDatabaseWalletDetails.Builder builder = GenerateAutonomousDatabaseWalletDetails.builder();
 
-        if (autonomousDatabaseConfiguration.getWalletPassword() != null) {
+        if (StringUtils.isNotEmpty(autonomousDatabaseConfiguration.getWalletPassword())) {
             builder.password(autonomousDatabaseConfiguration.getWalletPassword());
         }
 

--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/hikari/HikariPoolConfigurationListener.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/hikari/HikariPoolConfigurationListener.java
@@ -86,8 +86,8 @@ public class HikariPoolConfigurationListener implements BeanInitializedEventList
 
         if (autonomousDatabaseConfiguration == null) {
             LOG.trace("No AutonomousDatabaseConfiguration for [{}] datasource", beanName);
-        } else if (autonomousDatabaseConfiguration.getOcid() == null || autonomousDatabaseConfiguration.getWalletPassword() == null) {
-            LOG.trace("Skipping configuration of Oracle Wallet due to missin ocid or wallet password in " +
+        } else if (autonomousDatabaseConfiguration.getOcid() == null) {
+            LOG.trace("Skipping configuration of Oracle Wallet due to missing ocid in " +
                     "AutonomousDatabaseConfiguration for [{}] datasource", beanName);
         } else {
 

--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListener.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/ucp/UcpPoolConfigurationListener.java
@@ -90,8 +90,8 @@ public class UcpPoolConfigurationListener implements BeanInitializedEventListene
 
         if (autonomousDatabaseConfiguration == null) {
             LOG.trace("No AutonomousDatabaseConfiguration for [{}] datasource", beanName);
-        } else if (autonomousDatabaseConfiguration.getOcid() == null || autonomousDatabaseConfiguration.getWalletPassword() == null) {
-            LOG.trace("Skipping configuration of Oracle Wallet due to missing ocid or wallet password in " +
+        } else if (autonomousDatabaseConfiguration.getOcid() == null) {
+            LOG.trace("Skipping configuration of Oracle Wallet due to missing ocid in " +
                     "AutonomousDatabaseConfiguration for [{}] datasource", beanName);
         } else {
 

--- a/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
+++ b/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
@@ -15,13 +15,23 @@
  */
 package io.micronaut.oraclecloud.atp.jdbc;
 
+import com.oracle.bmc.database.Database;
+import com.oracle.bmc.database.model.GenerateAutonomousDatabaseWalletDetails;
+import com.oracle.bmc.database.requests.GenerateAutonomousDatabaseWalletRequest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OracleWalletArchiveProviderTest {
 
@@ -36,11 +46,43 @@ class OracleWalletArchiveProviderTest {
         assertEquals(expected, result);
     }
 
+    @Test
+    void buildsWalletRequestWhenPasswordIsOmitted() {
+        AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
+        cfg.setOcid("ocid1.autonomousdatabase.oc1..example");
+
+        AtomicReference<GenerateAutonomousDatabaseWalletRequest> walletRequest = new AtomicReference<>();
+        Database database = (Database) Proxy.newProxyInstance(
+            Database.class.getClassLoader(),
+            new Class<?>[] { Database.class },
+            (proxy, method, args) -> {
+                if ("generateAutonomousDatabaseWallet".equals(method.getName())) {
+                    walletRequest.set((GenerateAutonomousDatabaseWalletRequest) args[0]);
+                    throw new RequestCapturedException();
+                }
+                return null;
+            });
+        OracleWalletArchiveProvider provider = new OracleWalletArchiveProvider(database);
+
+        assertThrows(RequestCapturedException.class, () -> provider.loadWalletArchive(cfg));
+
+        GenerateAutonomousDatabaseWalletRequest request = walletRequest.get();
+        assertNotNull(request);
+        assertEquals("ocid1.autonomousdatabase.oc1..example", request.getAutonomousDatabaseId());
+        GenerateAutonomousDatabaseWalletDetails details = request.getGenerateAutonomousDatabaseWalletDetails();
+        assertNull(details.getPassword());
+        assertFalse(details.wasPropertyExplicitlySet("password"));
+    }
+
     private static Stream<Arguments> aliasCases() {
         return Stream.of(
             Arguments.of(null, null, "mydb", "mydb_high"),
             Arguments.of(null, "tp", "mydb", "mydb_tp"),
             Arguments.of("custom_alias", "tp", "mydb", "custom_alias")
         );
+    }
+
+    private static final class RequestCapturedException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
+++ b/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
@@ -18,7 +18,6 @@ package io.micronaut.oraclecloud.atp.jdbc;
 import com.oracle.bmc.database.Database;
 import com.oracle.bmc.database.model.GenerateAutonomousDatabaseWalletDetails;
 import com.oracle.bmc.database.requests.GenerateAutonomousDatabaseWalletRequest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,9 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OracleWalletArchiveProviderTest {
@@ -46,10 +43,12 @@ class OracleWalletArchiveProviderTest {
         assertEquals(expected, result);
     }
 
-    @Test
-    void buildsWalletRequestWhenPasswordIsOmitted() {
+    @ParameterizedTest
+    @MethodSource("walletPasswordCases")
+    void buildsWalletRequestWithExpectedPassword(String walletPassword, String expectedPassword, boolean explicitlySet) {
         AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
         cfg.setOcid("ocid1.autonomousdatabase.oc1..example");
+        cfg.setWalletPassword(walletPassword);
 
         AtomicReference<GenerateAutonomousDatabaseWalletRequest> walletRequest = new AtomicReference<>();
         Database database = (Database) Proxy.newProxyInstance(
@@ -70,8 +69,8 @@ class OracleWalletArchiveProviderTest {
         assertNotNull(request);
         assertEquals("ocid1.autonomousdatabase.oc1..example", request.getAutonomousDatabaseId());
         GenerateAutonomousDatabaseWalletDetails details = request.getGenerateAutonomousDatabaseWalletDetails();
-        assertNull(details.getPassword());
-        assertFalse(details.wasPropertyExplicitlySet("password"));
+        assertEquals(expectedPassword, details.getPassword());
+        assertEquals(explicitlySet, details.wasPropertyExplicitlySet("password"));
     }
 
     private static Stream<Arguments> aliasCases() {
@@ -79,6 +78,14 @@ class OracleWalletArchiveProviderTest {
             Arguments.of(null, null, "mydb", "mydb_high"),
             Arguments.of(null, "tp", "mydb", "mydb_tp"),
             Arguments.of("custom_alias", "tp", "mydb", "custom_alias")
+        );
+    }
+
+    private static Stream<Arguments> walletPasswordCases() {
+        return Stream.of(
+            Arguments.of(null, null, false),
+            Arguments.of("", null, false),
+            Arguments.of("FooBar.123", "FooBar.123", true)
         );
     }
 

--- a/src/main/docs/guide/autonomousDatabase.adoc
+++ b/src/main/docs/guide/autonomousDatabase.adoc
@@ -58,7 +58,7 @@ datasources:
     password: bar
 ----
 - `ocid` specifies the Autonomous Database id
-- the optional `wallet-password` property encrypts the keys inside the wallet. When set, it must be at least eight characters long, include at least one letter, and either one numeric character or one special character
+- the optional `wallet-password` property encrypts the keys inside the wallet. When set to a non-empty value, it must be at least eight characters long, include at least one letter, and either one numeric character or one special character
 - specify the database `username` and `password`
 - optionally `service-alias-suffix` controls the suffix used when computing the default service alias using database name and given service alias suffix; defaults to `high` (e.g., set to `tp`)
 

--- a/src/main/docs/guide/autonomousDatabase.adoc
+++ b/src/main/docs/guide/autonomousDatabase.adoc
@@ -54,12 +54,11 @@ To use automated data source configuration from the Wallet, provide a configurat
 datasources:
   default:
     ocid: ocid1.autonomousdatabase.oc1.....
-    walletPassword: micronaut.1
     username: foo
     password: bar
 ----
 - `ocid` specifies the Autonomous Database id
-- `wallet-password` encrypts the keys inside the wallet. It must be at least eight characters long, include at least one letter, and either one numeric character or one special character)
+- the optional `wallet-password` property encrypts the keys inside the wallet. When set, it must be at least eight characters long, include at least one letter, and either one numeric character or one special character
 - specify the database `username` and `password`
 - optionally `service-alias-suffix` controls the suffix used when computing the default service alias using database name and given service alias suffix; defaults to `high` (e.g., set to `tp`)
 


### PR DESCRIPTION
## Summary
- add Hikari regression coverage when the ATP wallet password is omitted
- add UCP regression coverage when the ATP wallet password is omitted

## Verification
- ./gradlew test --tests '*HikariPoolConfigurationListenerSpec' --tests '*UcpPoolConfigurationListenerSpec'