### PR TITLE
Add OCI Streaming module auto-configuration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ managed-apache-http-core5 = "5.4.2"
 micronaut-discovery-client = "5.0.0-RC1"
 micronaut-gradle-plugin = "5.0.0-M1"
 micronaut-groovy = "5.0.0"
+micronaut-kafka = "6.0.0-M2"
 micronaut-kotlin = "5.0.0-RC1"
 micronaut-kubernetes = "8.0.0-RC1"
 micronaut-reactor = "4.0.0"
@@ -44,6 +45,7 @@ micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'mi
 # micronaut boms
 micronaut-discovery-client = { module = "io.micronaut.discovery:micronaut-discovery-client-bom", version.ref = "micronaut-discovery-client" }
 micronaut-groovy = { module = "io.micronaut.groovy:micronaut-groovy-bom", version.ref = "micronaut-groovy" }
+micronaut-kafka = { module = "io.micronaut.kafka:micronaut-kafka-bom", version.ref = "micronaut-kafka" }
 micronaut-kotlin = { module = "io.micronaut.kotlin:micronaut-kotlin-bom", version.ref = "micronaut-kotlin" }
 micronaut-kubernetes = { module = "io.micronaut.kubernetes:micronaut-kubernetes-bom", version.ref = "micronaut-kubernetes" }
 micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-bom", version.ref = "micronaut-micrometer" }
@@ -74,6 +76,7 @@ oci-disasterrecovery = { module = 'com.oracle.oci.sdk:oci-java-sdk-disasterrecov
 oci-encryption = { module = 'com.oracle.oci.sdk:oci-java-sdk-encryption', version.ref = "oci" }
 oci-objectstorage = { module = 'com.oracle.oci.sdk:oci-java-sdk-objectstorage', version.ref = "oci" }
 oci-oke-workload-identity = { module = 'com.oracle.oci.sdk:oci-java-sdk-addons-oke-workload-identity', version.ref = "oci" }
+oci-sasl = { module = 'com.oracle.oci.sdk:oci-java-sdk-addons-sasl', version.ref = "oci" }
 oracle-jdbc-bom = { module = "com.oracle.database.jdbc:ojdbc-bom" }
 oracle-security-cert = { module = "com.oracle.database.security:osdt_cert", version.ref = "oracle-database-security" }
 oracle-security-core = { module = "com.oracle.database.security:osdt_core", version.ref = "oracle-database-security" }

--- a/oraclecloud-streaming/build.gradle
+++ b/oraclecloud-streaming/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'io.micronaut.build.internal.oraclecloud-module'
+}
+
+dependencies {
+    api(mnKafka.micronaut.kafka)
+    api(projects.micronautOraclecloudCommon)
+    api(projects.micronautOraclecloudBmcStreaming)
+    implementation(libs.oci.sasl)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("6.0.0")
+}

--- a/oraclecloud-streaming/build.gradle
+++ b/oraclecloud-streaming/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("6.0.0")
+    binaryCompatibility.enabledAfter("6.0.1")
 }

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingConfiguration.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingConfiguration.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.streaming;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.oraclecloud.core.OracleCloudCoreFactory;
+
+/**
+ * Configuration for OCI Streaming Kafka compatibility.
+ *
+ * @since 6.0.0
+ */
+@ConfigurationProperties(OracleCloudStreamingConfiguration.PREFIX)
+@Requires(property = OracleCloudStreamingConfiguration.PREFIX + ".stream-pool-id")
+@Requires(property = OracleCloudStreamingConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+public class OracleCloudStreamingConfiguration implements Toggleable {
+    /**
+     * The OCI Streaming configuration prefix.
+     */
+    public static final String PREFIX = OracleCloudCoreFactory.ORACLE_CLOUD + ".streaming";
+
+    private boolean enabled = true;
+    private AuthenticationMode authMode;
+    private String authToken;
+    private String bootstrapServers;
+    private String configFile;
+    private String domainName;
+    private String metadataBaseUrl;
+    private String profile;
+    private String region;
+    private String streamPoolId;
+    private String tenancyName;
+    private String userName;
+    private String username;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Whether OCI Streaming Kafka configuration is enabled.
+     *
+     * @param enabled Whether configuration is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return The authentication mode
+     */
+    public AuthenticationMode getAuthMode() {
+        return authMode;
+    }
+
+    /**
+     * Sets the authentication mode. If unset, auth token mode is used when an auth token is configured,
+     * otherwise user principal mode is used.
+     *
+     * @param authMode The authentication mode
+     */
+    public void setAuthMode(AuthenticationMode authMode) {
+        this.authMode = authMode;
+    }
+
+    /**
+     * @return The OCI auth token for {@link AuthenticationMode#AUTH_TOKEN}
+     */
+    public String getAuthToken() {
+        return authToken;
+    }
+
+    /**
+     * @param authToken The OCI auth token for {@link AuthenticationMode#AUTH_TOKEN}
+     */
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    /**
+     * @return Explicit Kafka bootstrap servers
+     */
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+    /**
+     * @param bootstrapServers Explicit Kafka bootstrap servers
+     */
+    public void setBootstrapServers(String bootstrapServers) {
+        this.bootstrapServers = bootstrapServers;
+    }
+
+    /**
+     * @return OCI SDK config file for {@link AuthenticationMode#USER_PRINCIPAL}
+     */
+    public String getConfigFile() {
+        return configFile;
+    }
+
+    /**
+     * @param configFile OCI SDK config file for {@link AuthenticationMode#USER_PRINCIPAL}
+     */
+    public void setConfigFile(String configFile) {
+        this.configFile = configFile;
+    }
+
+    /**
+     * @return Identity domain name for auth-token usernames
+     */
+    public String getDomainName() {
+        return domainName;
+    }
+
+    /**
+     * @param domainName Identity domain name for auth-token usernames
+     */
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+
+    /**
+     * @return Instance metadata base URL for {@link AuthenticationMode#INSTANCE_PRINCIPAL}
+     */
+    public String getMetadataBaseUrl() {
+        return metadataBaseUrl;
+    }
+
+    /**
+     * @param metadataBaseUrl Instance metadata base URL for {@link AuthenticationMode#INSTANCE_PRINCIPAL}
+     */
+    public void setMetadataBaseUrl(String metadataBaseUrl) {
+        this.metadataBaseUrl = metadataBaseUrl;
+    }
+
+    /**
+     * @return OCI SDK profile for {@link AuthenticationMode#USER_PRINCIPAL}
+     */
+    public String getProfile() {
+        return profile;
+    }
+
+    /**
+     * @param profile OCI SDK profile for {@link AuthenticationMode#USER_PRINCIPAL}
+     */
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+
+    /**
+     * @return OCI region ID used to derive bootstrap servers
+     */
+    public String getRegion() {
+        return region;
+    }
+
+    /**
+     * @param region OCI region ID used to derive bootstrap servers
+     */
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    /**
+     * @return OCI stream pool OCID
+     */
+    public String getStreamPoolId() {
+        return streamPoolId;
+    }
+
+    /**
+     * @param streamPoolId OCI stream pool OCID
+     */
+    public void setStreamPoolId(String streamPoolId) {
+        this.streamPoolId = streamPoolId;
+    }
+
+    /**
+     * @return Tenancy name for auth-token usernames
+     */
+    public String getTenancyName() {
+        return tenancyName;
+    }
+
+    /**
+     * @param tenancyName Tenancy name for auth-token usernames
+     */
+    public void setTenancyName(String tenancyName) {
+        this.tenancyName = tenancyName;
+    }
+
+    /**
+     * @return User name for auth-token usernames
+     */
+    public String getUserName() {
+        return userName;
+    }
+
+    /**
+     * @param userName User name for auth-token usernames
+     */
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    /**
+     * @return Full OCI Streaming Kafka username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * @param username Full OCI Streaming Kafka username
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * OCI Streaming Kafka authentication modes.
+     */
+    public enum AuthenticationMode {
+        /**
+         * Use a Kafka SASL/PLAIN username and OCI auth token.
+         */
+        AUTH_TOKEN,
+
+        /**
+         * Use OCI SDK instance principals.
+         */
+        INSTANCE_PRINCIPAL,
+
+        /**
+         * Use OCI SDK resource principals.
+         */
+        RESOURCE_PRINCIPAL,
+
+        /**
+         * Use an OCI SDK config file user principal.
+         */
+        USER_PRINCIPAL
+    }
+}

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingConfiguration.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingConfiguration.java
@@ -46,7 +46,6 @@ public class OracleCloudStreamingConfiguration implements Toggleable {
     private String region;
     private String streamPoolId;
     private String tenancyName;
-    private String userName;
     private String username;
 
     @Override
@@ -207,20 +206,6 @@ public class OracleCloudStreamingConfiguration implements Toggleable {
     }
 
     /**
-     * @return User name for auth-token usernames
-     */
-    public String getUserName() {
-        return userName;
-    }
-
-    /**
-     * @param userName User name for auth-token usernames
-     */
-    public void setUserName(String userName) {
-        this.userName = userName;
-    }
-
-    /**
      * @return Full OCI Streaming Kafka username
      */
     public String getUsername() {
@@ -232,6 +217,28 @@ public class OracleCloudStreamingConfiguration implements Toggleable {
      */
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    /**
+     * Auth-token username parts configuration.
+     */
+    @ConfigurationProperties("")
+    public static class AuthTokenUsernameConfiguration {
+        private String userName;
+
+        /**
+         * @return User name for auth-token usernames
+         */
+        public String getUserName() {
+            return userName;
+        }
+
+        /**
+         * @param userName User name for auth-token usernames
+         */
+        public void setUserName(String userName) {
+            this.userName = userName;
+        }
     }
 
     /**

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
@@ -120,7 +120,12 @@ public class OracleCloudStreamingKafkaConfiguration
 
     private Region resolveRegion() {
         if (StringUtils.isNotEmpty(streamingConfiguration.getRegion())) {
-            return Region.fromRegionCodeOrId(streamingConfiguration.getRegion());
+            try {
+                return Region.fromRegionCodeOrId(streamingConfiguration.getRegion());
+            } catch (IllegalArgumentException e) {
+                throw new ConfigurationException("Invalid OCI Streaming region [" +
+                    OracleCloudStreamingConfiguration.PREFIX + ".region]: " + streamingConfiguration.getRegion(), e);
+            }
         }
         if (regionProvider != null) {
             return regionProvider.getRegion();

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
@@ -62,18 +62,22 @@ public class OracleCloudStreamingKafkaConfiguration
     private static final String RETRIES = "5";
 
     private final OracleCloudStreamingConfiguration streamingConfiguration;
+    private final OracleCloudStreamingConfiguration.AuthTokenUsernameConfiguration authTokenUsernameConfiguration;
     private final RegionProvider regionProvider;
     private final Environment environment;
 
     /**
      * @param streamingConfiguration The OCI Streaming configuration
+     * @param authTokenUsernameConfiguration The auth-token username parts configuration
      * @param regionProvider The OCI region provider
      * @param environment The environment
      */
     public OracleCloudStreamingKafkaConfiguration(OracleCloudStreamingConfiguration streamingConfiguration,
+                                                  OracleCloudStreamingConfiguration.AuthTokenUsernameConfiguration authTokenUsernameConfiguration,
                                                   @Nullable RegionProvider regionProvider,
                                                   Environment environment) {
         this.streamingConfiguration = streamingConfiguration;
+        this.authTokenUsernameConfiguration = authTokenUsernameConfiguration;
         this.regionProvider = regionProvider;
         this.environment = environment;
     }
@@ -172,7 +176,7 @@ public class OracleCloudStreamingKafkaConfiguration
             return streamingConfiguration.getUsername();
         }
         if (StringUtils.isEmpty(streamingConfiguration.getTenancyName()) ||
-            StringUtils.isEmpty(streamingConfiguration.getUserName())) {
+            StringUtils.isEmpty(authTokenUsernameConfiguration.getUserName())) {
             throw new ConfigurationException("OCI Streaming auth-token mode requires either [" +
                 OracleCloudStreamingConfiguration.PREFIX + ".username] or both [" +
                 OracleCloudStreamingConfiguration.PREFIX + ".tenancy-name] and [" +
@@ -181,11 +185,11 @@ public class OracleCloudStreamingKafkaConfiguration
         if (StringUtils.isNotEmpty(streamingConfiguration.getDomainName())) {
             return streamingConfiguration.getTenancyName() + "/" +
                 streamingConfiguration.getDomainName() + "/" +
-                streamingConfiguration.getUserName() + "/" +
+                authTokenUsernameConfiguration.getUserName() + "/" +
                 streamingConfiguration.getStreamPoolId();
         }
         return streamingConfiguration.getTenancyName() + "/" +
-            streamingConfiguration.getUserName() + "/" +
+            authTokenUsernameConfiguration.getUserName() + "/" +
             streamingConfiguration.getStreamPoolId();
     }
 

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.streaming;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.RegionProvider;
+import com.oracle.bmc.auth.sasl.InstancePrincipalsLoginModule;
+import com.oracle.bmc.auth.sasl.OciMechanism;
+import com.oracle.bmc.auth.sasl.ResourcePrincipalsLoginModule;
+import com.oracle.bmc.auth.sasl.UserPrincipalsLoginModule;
+import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+
+import java.util.Properties;
+
+/**
+ * Configures Micronaut Kafka defaults for OCI Streaming.
+ *
+ * @since 6.0.0
+ */
+@Singleton
+@Requires(classes = KafkaDefaultConfiguration.class)
+@Requires(bean = OracleCloudStreamingConfiguration.class)
+@Internal
+public class OracleCloudStreamingKafkaConfiguration
+    implements BeanCreatedEventListener<KafkaDefaultConfiguration>, Ordered {
+    private static final int POSITION = Ordered.HIGHEST_PRECEDENCE + 100;
+    private static final String STREAM_POOL_INTENT_PREFIX = "streamPoolId:";
+    private static final String DEFAULT_SECOND_LEVEL_DOMAIN = "oraclecloud.com";
+    private static final String BOOTSTRAP_SERVERS_TEMPLATE = "streaming.%s.oci.%s:9092";
+    private static final String KAFKA_PREFIX = "kafka.";
+    private static final String SECURITY_PROTOCOL = "SASL_SSL";
+    private static final String SASL_PLAIN = "PLAIN";
+    private static final String PLAIN_LOGIN_MODULE = "org.apache.kafka.common.security.plain.PlainLoginModule";
+    private static final String MAX_REQUEST_SIZE = "1048576";
+    private static final String RETRIES = "5";
+
+    private final OracleCloudStreamingConfiguration streamingConfiguration;
+    private final RegionProvider regionProvider;
+    private final Environment environment;
+
+    /**
+     * @param streamingConfiguration The OCI Streaming configuration
+     * @param regionProvider The OCI region provider
+     * @param environment The environment
+     */
+    public OracleCloudStreamingKafkaConfiguration(OracleCloudStreamingConfiguration streamingConfiguration,
+                                                  @Nullable RegionProvider regionProvider,
+                                                  Environment environment) {
+        this.streamingConfiguration = streamingConfiguration;
+        this.regionProvider = regionProvider;
+        this.environment = environment;
+    }
+
+    @Override
+    public int getOrder() {
+        return POSITION;
+    }
+
+    @Override
+    public KafkaDefaultConfiguration onCreated(BeanCreatedEvent<KafkaDefaultConfiguration> event) {
+        Properties kafkaProperties = event.getBean().getConfig();
+        putIfNotConfigured(kafkaProperties, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, resolveBootstrapServers());
+        putIfNotConfigured(kafkaProperties, CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SECURITY_PROTOCOL);
+        putIfNotConfigured(kafkaProperties, SaslConfigs.SASL_MECHANISM, resolveSaslMechanism());
+        putIfNotConfigured(kafkaProperties, SaslConfigs.SASL_JAAS_CONFIG, resolveJaasConfig());
+        putIfNotConfigured(kafkaProperties, ProducerConfig.RETRIES_CONFIG, RETRIES);
+        putIfNotConfigured(kafkaProperties, ProducerConfig.MAX_REQUEST_SIZE_CONFIG, MAX_REQUEST_SIZE);
+        putIfNotConfigured(kafkaProperties, ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, MAX_REQUEST_SIZE);
+        return event.getBean();
+    }
+
+    private String resolveBootstrapServers() {
+        if (StringUtils.isNotEmpty(streamingConfiguration.getBootstrapServers())) {
+            return streamingConfiguration.getBootstrapServers();
+        }
+        Region ociRegion = resolveRegion();
+        if (ociRegion == null) {
+            throw new ConfigurationException("OCI Streaming requires either [" +
+                OracleCloudStreamingConfiguration.PREFIX + ".bootstrap-servers] or an OCI region");
+        }
+        return String.format(
+            BOOTSTRAP_SERVERS_TEMPLATE,
+            ociRegion.getRegionId(),
+            resolveSecondLevelDomain(ociRegion)
+        );
+    }
+
+    private Region resolveRegion() {
+        if (StringUtils.isNotEmpty(streamingConfiguration.getRegion())) {
+            return Region.fromRegionCodeOrId(streamingConfiguration.getRegion());
+        }
+        if (regionProvider != null) {
+            return regionProvider.getRegion();
+        }
+        return null;
+    }
+
+    private String resolveSecondLevelDomain(Region region) {
+        if (region.getRealm() == null || StringUtils.isEmpty(region.getRealm().getSecondLevelDomain())) {
+            return DEFAULT_SECOND_LEVEL_DOMAIN;
+        }
+        return region.getRealm().getSecondLevelDomain();
+    }
+
+    private String resolveSaslMechanism() {
+        if (resolveAuthenticationMode() == OracleCloudStreamingConfiguration.AuthenticationMode.AUTH_TOKEN) {
+            return SASL_PLAIN;
+        }
+        return OciMechanism.OCI_RSA_SHA256.mechanismName();
+    }
+
+    private String resolveJaasConfig() {
+        return switch (resolveAuthenticationMode()) {
+            case AUTH_TOKEN -> plainLoginModule();
+            case INSTANCE_PRINCIPAL -> ociLoginModule(InstancePrincipalsLoginModule.class.getName(), metadataOption());
+            case RESOURCE_PRINCIPAL -> ociLoginModule(ResourcePrincipalsLoginModule.class.getName(), "");
+            case USER_PRINCIPAL -> ociLoginModule(UserPrincipalsLoginModule.class.getName(), userPrincipalOptions());
+        };
+    }
+
+    private OracleCloudStreamingConfiguration.AuthenticationMode resolveAuthenticationMode() {
+        OracleCloudStreamingConfiguration.AuthenticationMode authMode = streamingConfiguration.getAuthMode();
+        if (authMode != null) {
+            return authMode;
+        }
+        if (StringUtils.isNotEmpty(streamingConfiguration.getAuthToken())) {
+            return OracleCloudStreamingConfiguration.AuthenticationMode.AUTH_TOKEN;
+        }
+        return OracleCloudStreamingConfiguration.AuthenticationMode.USER_PRINCIPAL;
+    }
+
+    private String plainLoginModule() {
+        String username = resolveUsername();
+        String authToken = streamingConfiguration.getAuthToken();
+        if (StringUtils.isEmpty(authToken)) {
+            throw new ConfigurationException("OCI Streaming auth-token mode requires [" +
+                OracleCloudStreamingConfiguration.PREFIX + ".auth-token]");
+        }
+        return PLAIN_LOGIN_MODULE + " required username=\"" + escapeJaas(username) +
+            "\" password=\"" + escapeJaas(authToken) + "\";";
+    }
+
+    private String resolveUsername() {
+        if (StringUtils.isNotEmpty(streamingConfiguration.getUsername())) {
+            return streamingConfiguration.getUsername();
+        }
+        if (StringUtils.isEmpty(streamingConfiguration.getTenancyName()) ||
+            StringUtils.isEmpty(streamingConfiguration.getUserName())) {
+            throw new ConfigurationException("OCI Streaming auth-token mode requires either [" +
+                OracleCloudStreamingConfiguration.PREFIX + ".username] or both [" +
+                OracleCloudStreamingConfiguration.PREFIX + ".tenancy-name] and [" +
+                OracleCloudStreamingConfiguration.PREFIX + ".user-name]");
+        }
+        if (StringUtils.isNotEmpty(streamingConfiguration.getDomainName())) {
+            return streamingConfiguration.getTenancyName() + "/" +
+                streamingConfiguration.getDomainName() + "/" +
+                streamingConfiguration.getUserName() + "/" +
+                streamingConfiguration.getStreamPoolId();
+        }
+        return streamingConfiguration.getTenancyName() + "/" +
+            streamingConfiguration.getUserName() + "/" +
+            streamingConfiguration.getStreamPoolId();
+    }
+
+    private String ociLoginModule(String loginModule, String options) {
+        StringBuilder builder = new StringBuilder(loginModule)
+            .append(" required intent=\"")
+            .append(escapeJaas(STREAM_POOL_INTENT_PREFIX + streamingConfiguration.getStreamPoolId()))
+            .append('"');
+        if (StringUtils.isNotEmpty(options)) {
+            builder.append(' ').append(options);
+        }
+        return builder.append(';').toString();
+    }
+
+    private String metadataOption() {
+        if (StringUtils.isEmpty(streamingConfiguration.getMetadataBaseUrl())) {
+            return "";
+        }
+        return "metadataBaseUrl=\"" + escapeJaas(streamingConfiguration.getMetadataBaseUrl()) + "\"";
+    }
+
+    private String userPrincipalOptions() {
+        StringBuilder options = new StringBuilder();
+        appendJaasOption(options, "config", streamingConfiguration.getConfigFile());
+        appendJaasOption(options, "profile", streamingConfiguration.getProfile());
+        return options.toString();
+    }
+
+    private static void appendJaasOption(StringBuilder options, String name, String value) {
+        if (StringUtils.isNotEmpty(value)) {
+            if (!options.isEmpty()) {
+                options.append(' ');
+            }
+            options.append(name).append("=\"").append(escapeJaas(value)).append('"');
+        }
+    }
+
+    private void putIfNotConfigured(Properties properties, String key, String value) {
+        if (!environment.containsProperty(KAFKA_PREFIX + key)) {
+            properties.setProperty(key, value);
+        }
+    }
+
+    private static String escapeJaas(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfiguration.java
@@ -38,6 +38,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 
 import java.util.Properties;
+import java.util.function.Supplier;
 
 /**
  * Configures Micronaut Kafka defaults for OCI Streaming.
@@ -55,6 +56,7 @@ public class OracleCloudStreamingKafkaConfiguration
     private static final String DEFAULT_SECOND_LEVEL_DOMAIN = "oraclecloud.com";
     private static final String BOOTSTRAP_SERVERS_TEMPLATE = "streaming.%s.oci.%s:9092";
     private static final String KAFKA_PREFIX = "kafka.";
+    private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
     private static final String SECURITY_PROTOCOL = "SASL_SSL";
     private static final String SASL_PLAIN = "PLAIN";
     private static final String PLAIN_LOGIN_MODULE = "org.apache.kafka.common.security.plain.PlainLoginModule";
@@ -90,13 +92,13 @@ public class OracleCloudStreamingKafkaConfiguration
     @Override
     public KafkaDefaultConfiguration onCreated(BeanCreatedEvent<KafkaDefaultConfiguration> event) {
         Properties kafkaProperties = event.getBean().getConfig();
-        putIfNotConfigured(kafkaProperties, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, resolveBootstrapServers());
-        putIfNotConfigured(kafkaProperties, CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SECURITY_PROTOCOL);
-        putIfNotConfigured(kafkaProperties, SaslConfigs.SASL_MECHANISM, resolveSaslMechanism());
-        putIfNotConfigured(kafkaProperties, SaslConfigs.SASL_JAAS_CONFIG, resolveJaasConfig());
-        putIfNotConfigured(kafkaProperties, ProducerConfig.RETRIES_CONFIG, RETRIES);
-        putIfNotConfigured(kafkaProperties, ProducerConfig.MAX_REQUEST_SIZE_CONFIG, MAX_REQUEST_SIZE);
-        putIfNotConfigured(kafkaProperties, ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, MAX_REQUEST_SIZE);
+        putIfNotConfigured(kafkaProperties, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this::resolveBootstrapServers);
+        putIfNotConfigured(kafkaProperties, CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, () -> SECURITY_PROTOCOL);
+        putIfNotConfigured(kafkaProperties, SaslConfigs.SASL_MECHANISM, this::resolveSaslMechanism);
+        putIfNotConfigured(kafkaProperties, SaslConfigs.SASL_JAAS_CONFIG, this::resolveJaasConfig);
+        putIfNotConfigured(kafkaProperties, ProducerConfig.RETRIES_CONFIG, () -> RETRIES);
+        putIfNotConfigured(kafkaProperties, ProducerConfig.MAX_REQUEST_SIZE_CONFIG, () -> MAX_REQUEST_SIZE);
+        putIfNotConfigured(kafkaProperties, ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, () -> MAX_REQUEST_SIZE);
         return event.getBean();
     }
 
@@ -227,10 +229,16 @@ public class OracleCloudStreamingKafkaConfiguration
         }
     }
 
-    private void putIfNotConfigured(Properties properties, String key, String value) {
-        if (!environment.containsProperty(KAFKA_PREFIX + key)) {
-            properties.setProperty(key, value);
+    private void putIfNotConfigured(Properties properties, String key, Supplier<String> value) {
+        if (!isConfigured(properties, key) && !environment.containsProperty(KAFKA_PREFIX + key)) {
+            properties.setProperty(key, value.get());
         }
+    }
+
+    private static boolean isConfigured(Properties properties, String key) {
+        return properties.containsKey(key) &&
+            !(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG.equals(key) &&
+                DEFAULT_BOOTSTRAP_SERVERS.equals(properties.getProperty(key)));
     }
 
     private static String escapeJaas(String value) {

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaFactory.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.streaming;
+
+import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+
+/**
+ * Creates Kafka configuration when OCI Streaming is configured without a separate {@code kafka.*} section.
+ *
+ * @since 6.0.0
+ */
+@Factory
+@Requires(classes = KafkaDefaultConfiguration.class)
+@Requires(bean = OracleCloudStreamingConfiguration.class)
+@Requires(property = "kafka.enabled", notEquals = StringUtils.FALSE)
+final class OracleCloudStreamingKafkaFactory {
+
+    @Singleton
+    @Requires(missingBeans = KafkaDefaultConfiguration.class)
+    KafkaDefaultConfiguration kafkaDefaultConfiguration(Environment environment) {
+        return new KafkaDefaultConfiguration(environment);
+    }
+}

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaHealthConfiguration.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaHealthConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.streaming;
+
+import io.micronaut.configuration.kafka.config.KafkaHealthConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+
+/**
+ * Configures Kafka health for OCI Streaming's restricted Kafka API.
+ *
+ * @since 6.0.0
+ */
+@Singleton
+@Requires(classes = KafkaHealthConfigurationProperties.class)
+@Requires(bean = OracleCloudStreamingConfiguration.class)
+@Internal
+public class OracleCloudStreamingKafkaHealthConfiguration
+    implements BeanCreatedEventListener<KafkaHealthConfigurationProperties> {
+    private static final String KAFKA_HEALTH_RESTRICTED = "kafka.health.restricted";
+
+    private final Environment environment;
+
+    /**
+     * @param environment The environment
+     */
+    public OracleCloudStreamingKafkaHealthConfiguration(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public KafkaHealthConfigurationProperties onCreated(
+        BeanCreatedEvent<KafkaHealthConfigurationProperties> event) {
+        KafkaHealthConfigurationProperties bean = event.getBean();
+        if (!environment.containsProperty(KAFKA_HEALTH_RESTRICTED)) {
+            bean.setRestricted(true);
+        }
+        return bean;
+    }
+}

--- a/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/package-info.java
+++ b/oraclecloud-streaming/src/main/java/io/micronaut/oraclecloud/streaming/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Support for OCI Streaming Kafka compatibility.
+ */
+@Experimental
+package io.micronaut.oraclecloud.streaming;
+
+import io.micronaut.core.annotation.Experimental;

--- a/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
+++ b/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
@@ -18,7 +18,12 @@ package io.micronaut.oraclecloud.streaming;
 import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
 import io.micronaut.configuration.kafka.config.KafkaHealthConfigurationProperties;
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Singleton;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -191,6 +196,11 @@ class OracleCloudStreamingKafkaConfigurationTest {
         try (ApplicationContext context = ApplicationContext.run(Map.of(
             "kafka.bootstrap.servers", "custom.example.com:9092",
             "kafka.security.protocol", "PLAINTEXT",
+            "kafka.sasl.mechanism", "CUSTOM",
+            "kafka.sasl.jaas.config", "custom.LoginModule required;",
+            "kafka.retries", "9",
+            "kafka.max.request.size", "2097152",
+            "kafka.max.partition.fetch.bytes", "3145728",
             "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
             "oci.streaming.stream-pool-id", STREAM_POOL_ID,
             "oci.streaming.auth-mode", "resource-principal"
@@ -199,7 +209,29 @@ class OracleCloudStreamingKafkaConfigurationTest {
 
             assertEquals("custom.example.com:9092", properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
             assertEquals("PLAINTEXT", properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
-            assertEquals("OCI-RSA-SHA256", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+            assertEquals("CUSTOM", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+            assertEquals("custom.LoginModule required;", properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+            assertEquals("9", properties.getProperty(ProducerConfig.RETRIES_CONFIG));
+            assertEquals("2097152", properties.getProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG));
+            assertEquals("3145728", properties.getProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG));
+        }
+    }
+
+    @Test
+    void preservesProgrammaticKafkaProperties() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "spec.name", "preserves-programmatic-kafka-properties",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("programmatic.example.com:9092", properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            assertEquals("PLAINTEXT", properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+            assertEquals("PROGRAMMATIC", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+            assertEquals("programmatic.LoginModule required;", properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+            assertEquals("13", properties.getProperty(ProducerConfig.RETRIES_CONFIG));
+            assertEquals("4194304", properties.getProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG));
+            assertEquals("5242880", properties.getProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG));
         }
     }
 
@@ -257,5 +289,28 @@ class OracleCloudStreamingKafkaConfigurationTest {
             cause = cause.getCause();
         }
         return cause;
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "preserves-programmatic-kafka-properties")
+    static final class ProgrammaticKafkaConfiguration implements BeanCreatedEventListener<KafkaDefaultConfiguration>, Ordered {
+
+        @Override
+        public int getOrder() {
+            return Ordered.HIGHEST_PRECEDENCE;
+        }
+
+        @Override
+        public KafkaDefaultConfiguration onCreated(BeanCreatedEvent<KafkaDefaultConfiguration> event) {
+            Properties properties = event.getBean().getConfig();
+            properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "programmatic.example.com:9092");
+            properties.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "PLAINTEXT");
+            properties.setProperty(SaslConfigs.SASL_MECHANISM, "PROGRAMMATIC");
+            properties.setProperty(SaslConfigs.SASL_JAAS_CONFIG, "programmatic.LoginModule required;");
+            properties.setProperty(ProducerConfig.RETRIES_CONFIG, "13");
+            properties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "4194304");
+            properties.setProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "5242880");
+            return event.getBean();
+        }
     }
 }

--- a/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
+++ b/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
@@ -92,6 +92,22 @@ class OracleCloudStreamingKafkaConfigurationTest {
     }
 
     @Test
+    void configuresKafkaForFullAuthTokenUsername() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.username", "exampletenant/streamuser/" + STREAM_POOL_ID,
+            "oci.streaming.auth-token", "secret"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                    "username=\"exampletenant/streamuser/" + STREAM_POOL_ID + "\" password=\"secret\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+        }
+    }
+
+    @Test
     void configuresBootstrapServersForRegionRealm() {
         try (ApplicationContext context = ApplicationContext.run(Map.of(
             "oci.streaming.region", "us-gov-phoenix-1",

--- a/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
+++ b/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.oraclecloud.streaming;
 
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.RegionProvider;
 import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
 import io.micronaut.configuration.kafka.config.KafkaHealthConfigurationProperties;
 import io.micronaut.context.ApplicationContext;
@@ -127,6 +129,21 @@ class OracleCloudStreamingKafkaConfigurationTest {
     }
 
     @Test
+    void configuresBootstrapServersFromRegionProvider() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "spec.name", "configures-bootstrap-servers-from-region-provider",
+            "oci.config.enabled", false,
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "resource-principal"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("streaming.eu-jovanovac-1.oci.oraclecloud20.com:9092",
+                properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        }
+    }
+
+    @Test
     void configuresKafkaForInstancePrincipals() {
         try (ApplicationContext context = ApplicationContext.run(Map.of(
             "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
@@ -161,6 +178,22 @@ class OracleCloudStreamingKafkaConfigurationTest {
     }
 
     @Test
+    void escapesAuthTokenJaasValues() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.username", "exampletenant/stream\\\"user/" + STREAM_POOL_ID,
+            "oci.streaming.auth-token", "sec\\\"ret"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                    "username=\"exampletenant/stream\\\\\\\"user/" + STREAM_POOL_ID + "\" password=\"sec\\\\\\\"ret\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+        }
+    }
+
+    @Test
     void configuresKafkaForUserPrincipals() {
         try (ApplicationContext context = ApplicationContext.run(Map.of(
             "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
@@ -175,6 +208,41 @@ class OracleCloudStreamingKafkaConfigurationTest {
             assertEquals("com.oracle.bmc.auth.sasl.UserPrincipalsLoginModule required " +
                     "intent=\"streamPoolId:" + STREAM_POOL_ID + "\" " +
                     "config=\"/home/user/.oci/config\" profile=\"STREAMING\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+        }
+    }
+
+    @Test
+    void escapesInstancePrincipalJaasValues() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", "ocid1.streampool.oc1.phx.stream\\\"pool",
+            "oci.streaming.auth-mode", "instance-principal",
+            "oci.streaming.metadata-base-url", "http://metadata.example.com/opc/\\\"v2"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("com.oracle.bmc.auth.sasl.InstancePrincipalsLoginModule required " +
+                    "intent=\"streamPoolId:ocid1.streampool.oc1.phx.stream\\\\\\\"pool\" " +
+                    "metadataBaseUrl=\"http://metadata.example.com/opc/\\\\\\\"v2\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+        }
+    }
+
+    @Test
+    void escapesUserPrincipalJaasValues() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "user-principal",
+            "oci.streaming.config-file", "/home/user/.oci/str\\\"eaming",
+            "oci.streaming.profile", "STR\\\"EAMING"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("com.oracle.bmc.auth.sasl.UserPrincipalsLoginModule required " +
+                    "intent=\"streamPoolId:" + STREAM_POOL_ID + "\" " +
+                    "config=\"/home/user/.oci/str\\\\\\\"eaming\" profile=\"STR\\\\\\\"EAMING\";",
                 properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
         }
     }
@@ -238,6 +306,7 @@ class OracleCloudStreamingKafkaConfigurationTest {
     @Test
     void failsWhenBootstrapServersAndRegionAreMissing() {
         try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.config.enabled", false,
             "oci.streaming.stream-pool-id", STREAM_POOL_ID,
             "oci.streaming.auth-mode", "resource-principal"
         ))) {
@@ -247,6 +316,22 @@ class OracleCloudStreamingKafkaConfigurationTest {
             Throwable cause = rootCause(exception);
             assertTrue(cause instanceof ConfigurationException);
             assertTrue(cause.getMessage().contains("bootstrap-servers"));
+        }
+    }
+
+    @Test
+    void failsWhenConfiguredRegionIsInvalid() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.region", "not-a-region",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "resource-principal"
+        ))) {
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> context.getBean(KafkaDefaultConfiguration.class));
+
+            ConfigurationException cause = findCause(exception, ConfigurationException.class);
+            assertTrue(cause.getMessage().contains("oci.streaming.region"));
+            assertTrue(cause.getMessage().contains("not-a-region"));
         }
     }
 
@@ -291,6 +376,17 @@ class OracleCloudStreamingKafkaConfigurationTest {
         return cause;
     }
 
+    private static <T extends Throwable> T findCause(Throwable throwable, Class<T> type) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (type.isInstance(cause)) {
+                return type.cast(cause);
+            }
+            cause = cause.getCause();
+        }
+        throw new AssertionError("Could not find cause of type " + type.getName(), throwable);
+    }
+
     @Singleton
     @Requires(property = "spec.name", value = "preserves-programmatic-kafka-properties")
     static final class ProgrammaticKafkaConfiguration implements BeanCreatedEventListener<KafkaDefaultConfiguration>, Ordered {
@@ -311,6 +407,16 @@ class OracleCloudStreamingKafkaConfigurationTest {
             properties.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "4194304");
             properties.setProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "5242880");
             return event.getBean();
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "configures-bootstrap-servers-from-region-provider")
+    static final class TestRegionProvider implements RegionProvider {
+
+        @Override
+        public Region getRegion() {
+            return Region.EU_JOVANOVAC_1;
         }
     }
 }

--- a/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
+++ b/oraclecloud-streaming/src/test/java/io/micronaut/oraclecloud/streaming/OracleCloudStreamingKafkaConfigurationTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.streaming;
+
+import io.micronaut.configuration.kafka.config.KafkaDefaultConfiguration;
+import io.micronaut.configuration.kafka.config.KafkaHealthConfigurationProperties;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.exceptions.ConfigurationException;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OracleCloudStreamingKafkaConfigurationTest {
+    private static final String STREAM_POOL_ID = "ocid1.streampool.oc1.phx.example";
+
+    @Test
+    void kafkaConfigurationIsNotCreatedWithoutStreamingConfiguration() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of("spec.name", getClass().getSimpleName()))) {
+            assertFalse(context.findBean(KafkaDefaultConfiguration.class).isPresent());
+        }
+    }
+
+    @Test
+    void kafkaConfigurationIsNotCreatedWhenStreamingIsDisabled() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.enabled", false,
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID
+        ))) {
+            assertFalse(context.findBean(OracleCloudStreamingConfiguration.class).isPresent());
+            assertFalse(context.findBean(KafkaDefaultConfiguration.class).isPresent());
+        }
+    }
+
+    @Test
+    void kafkaConfigurationIsNotCreatedWhenKafkaIsDisabled() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "kafka.enabled", false,
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID
+        ))) {
+            assertTrue(context.findBean(OracleCloudStreamingConfiguration.class).isPresent());
+            assertFalse(context.findBean(KafkaDefaultConfiguration.class).isPresent());
+        }
+    }
+
+    @Test
+    void configuresKafkaForAuthTokenStreaming() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.region", "us-phoenix-1",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.tenancy-name", "exampletenant",
+            "oci.streaming.domain-name", "Default",
+            "oci.streaming.user-name", "streamuser",
+            "oci.streaming.auth-token", "secret"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("streaming.us-phoenix-1.oci.oraclecloud.com:9092",
+                properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            assertEquals("SASL_SSL", properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+            assertEquals("PLAIN", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+            assertEquals("org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                    "username=\"exampletenant/Default/streamuser/" + STREAM_POOL_ID + "\" password=\"secret\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+            assertEquals("5", properties.getProperty(ProducerConfig.RETRIES_CONFIG));
+            assertEquals("1048576", properties.getProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG));
+            assertEquals("1048576", properties.getProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG));
+            assertTrue(context.getBean(KafkaHealthConfigurationProperties.class).isRestricted());
+        }
+    }
+
+    @Test
+    void configuresBootstrapServersForRegionRealm() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.region", "us-gov-phoenix-1",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "resource-principal"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("streaming.us-gov-phoenix-1.oci.oraclegovcloud.com:9092",
+                properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        }
+    }
+
+    @Test
+    void configuresKafkaForInstancePrincipals() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "instance-principal",
+            "oci.streaming.metadata-base-url", "http://169.254.169.254/opc/v2"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("streaming.example.com:9092", properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            assertEquals("OCI-RSA-SHA256", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+            assertEquals("com.oracle.bmc.auth.sasl.InstancePrincipalsLoginModule required " +
+                    "intent=\"streamPoolId:" + STREAM_POOL_ID + "\" metadataBaseUrl=\"http://169.254.169.254/opc/v2\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+        }
+    }
+
+    @Test
+    void configuresKafkaForResourcePrincipals() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "resource-principal"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("OCI-RSA-SHA256", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+            assertEquals("com.oracle.bmc.auth.sasl.ResourcePrincipalsLoginModule required " +
+                    "intent=\"streamPoolId:" + STREAM_POOL_ID + "\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+        }
+    }
+
+    @Test
+    void configuresKafkaForUserPrincipals() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "user-principal",
+            "oci.streaming.config-file", "/home/user/.oci/config",
+            "oci.streaming.profile", "STREAMING"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("OCI-RSA-SHA256", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+            assertEquals("com.oracle.bmc.auth.sasl.UserPrincipalsLoginModule required " +
+                    "intent=\"streamPoolId:" + STREAM_POOL_ID + "\" " +
+                    "config=\"/home/user/.oci/config\" profile=\"STREAMING\";",
+                properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG));
+        }
+    }
+
+    @Test
+    void preservesExplicitKafkaHealthRestriction() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "kafka.health.restricted", false,
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "resource-principal"
+        ))) {
+            assertFalse(context.getBean(KafkaHealthConfigurationProperties.class).isRestricted());
+        }
+    }
+
+    @Test
+    void preservesExplicitKafkaProperties() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "kafka.bootstrap.servers", "custom.example.com:9092",
+            "kafka.security.protocol", "PLAINTEXT",
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "resource-principal"
+        ))) {
+            Properties properties = context.getBean(KafkaDefaultConfiguration.class).getConfig();
+
+            assertEquals("custom.example.com:9092", properties.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+            assertEquals("PLAINTEXT", properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+            assertEquals("OCI-RSA-SHA256", properties.getProperty(SaslConfigs.SASL_MECHANISM));
+        }
+    }
+
+    @Test
+    void failsWhenBootstrapServersAndRegionAreMissing() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "resource-principal"
+        ))) {
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> context.getBean(KafkaDefaultConfiguration.class));
+
+            Throwable cause = rootCause(exception);
+            assertTrue(cause instanceof ConfigurationException);
+            assertTrue(cause.getMessage().contains("bootstrap-servers"));
+        }
+    }
+
+    @Test
+    void failsWhenAuthTokenModeDoesNotHaveAuthToken() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-mode", "auth-token",
+            "oci.streaming.username", "exampletenant/streamuser/" + STREAM_POOL_ID
+        ))) {
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> context.getBean(KafkaDefaultConfiguration.class));
+
+            Throwable cause = rootCause(exception);
+            assertTrue(cause instanceof ConfigurationException);
+            assertTrue(cause.getMessage().contains("auth-token"));
+        }
+    }
+
+    @Test
+    void failsWhenAuthTokenModeDoesNotHaveUsernameConfiguration() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "oci.streaming.bootstrap-servers", "streaming.example.com:9092",
+            "oci.streaming.stream-pool-id", STREAM_POOL_ID,
+            "oci.streaming.auth-token", "secret"
+        ))) {
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> context.getBean(KafkaDefaultConfiguration.class));
+
+            Throwable cause = rootCause(exception);
+            assertTrue(cause instanceof ConfigurationException);
+            assertTrue(cause.getMessage().contains("username"));
+        }
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ include("oraclecloud-logging")
 include("oraclecloud-micrometer")
 include("oraclecloud-oke-kubernetes-client")
 include("oraclecloud-oke-workload-identity")
+include("oraclecloud-streaming")
 include("oraclecloud-sdk-base")
 include("oraclecloud-sdk")
 include("oraclecloud-sdk-rxjava2")
@@ -74,6 +75,7 @@ configure<io.micronaut.build.MicronautBuildSettingsExtension> {
     importMicronautCatalog("micronaut-validation")
     importMicronautCatalog("micronaut-discovery-client")
     importMicronautCatalog("micronaut-kubernetes")
+    importMicronautCatalog("micronaut-kafka")
 }
 
 val libs = Toml.parse(File(rootProject.projectDir.absoluteFile, "gradle/libs.versions.toml").toPath())!!

--- a/src/main/docs/guide/modules.adoc
+++ b/src/main/docs/guide/modules.adoc
@@ -89,6 +89,12 @@ dependency:io.micronaut.oraclecloud:micronaut-oraclecloud-micrometer[]
 
 Provides support for sending https://micrometer.io[Micrometer] metrics to the https://docs.oracle.com/en-us/iaas/Content/Monitoring/Concepts/monitoringoverview.htm[Oracle Cloud Monitoring] service.
 
+=== micronaut-oraclecloud-streaming
+
+dependency:io.micronaut.oraclecloud:micronaut-oraclecloud-streaming[]
+
+Provides support for connecting Micronaut Kafka applications to https://docs.oracle.com/en-us/iaas/Content/Streaming/Concepts/streamingoverview.htm[OCI Streaming].
+
 === micronaut-oraclecloud-vault
 
 dependency:io.micronaut.oraclecloud:micronaut-oraclecloud-vault[]

--- a/src/main/docs/guide/streaming.adoc
+++ b/src/main/docs/guide/streaming.adoc
@@ -36,3 +36,5 @@ oci:
 The supported `auth-mode` values are `auth-token`, `instance-principal`, `resource-principal`, and `user-principal`. For user principals, set `config-file` and `profile` when the default OCI SDK config file or profile should not be used.
 
 The module only fills in Kafka properties that are not already configured. You can override any generated Kafka value under the `kafka` prefix, including `kafka.bootstrap.servers`, `kafka.security.protocol`, `kafka.sasl.mechanism`, and `kafka.sasl.jaas.config`. Programmatic `KafkaDefaultConfiguration` customizations are also preserved when they run before the OCI Streaming listener.
+
+By default, the module derives the public regional OCI Streaming Kafka endpoint from the configured region or OCI `RegionProvider`. Set `oci.streaming.bootstrap-servers` when your stream pool requires a private, custom, or nonstandard Kafka endpoint.

--- a/src/main/docs/guide/streaming.adoc
+++ b/src/main/docs/guide/streaming.adoc
@@ -1,0 +1,36 @@
+To use https://docs.oracle.com/en-us/iaas/Content/Streaming/Concepts/streamingoverview.htm[OCI Streaming] through Micronaut Kafka, add the following dependency:
+
+dependency:io.micronaut.oraclecloud:micronaut-oraclecloud-streaming[]
+
+The module adds Micronaut Kafka and the OCI Streaming SDK module, configures Kafka compatibility defaults, and switches Kafka health checks to restricted mode by default. Restricted health checks verify connectivity without cluster-wide Kafka admin permissions.
+
+For auth-token authentication, configure the stream pool, region, user, and token:
+
+[configuration]
+----
+oci:
+  streaming:
+    region: us-phoenix-1
+    stream-pool-id: ocid1.streampool.oc1.phx...
+    tenancy-name: mytenancy
+    domain-name: Default
+    user-name: stream-user
+    auth-token: ${OCI_STREAMING_AUTH_TOKEN}
+----
+
+If you already have the full OCI Streaming Kafka username, set `oci.streaming.username` instead of `tenancy-name`, `domain-name`, and `user-name`.
+
+Instance, resource, and user principal authentication are also supported:
+
+[configuration]
+----
+oci:
+  streaming:
+    region: us-phoenix-1
+    stream-pool-id: ocid1.streampool.oc1.phx...
+    auth-mode: instance-principal
+----
+
+The supported `auth-mode` values are `auth-token`, `instance-principal`, `resource-principal`, and `user-principal`. For user principals, set `config-file` and `profile` when the default OCI SDK config file or profile should not be used.
+
+The module only fills in Kafka properties that are not already configured. You can override any generated Kafka value under the `kafka` prefix, including `kafka.bootstrap.servers`, `kafka.security.protocol`, `kafka.sasl.mechanism`, and `kafka.sasl.jaas.config`.

--- a/src/main/docs/guide/streaming.adoc
+++ b/src/main/docs/guide/streaming.adoc
@@ -1,8 +1,10 @@
+= OCI Streaming
+
 To use https://docs.oracle.com/en-us/iaas/Content/Streaming/Concepts/streamingoverview.htm[OCI Streaming] through Micronaut Kafka, add the following dependency:
 
 dependency:io.micronaut.oraclecloud:micronaut-oraclecloud-streaming[]
 
-The module adds Micronaut Kafka and the OCI Streaming SDK module, configures Kafka compatibility defaults, and switches Kafka health checks to restricted mode by default. Restricted health checks verify connectivity without cluster-wide Kafka admin permissions.
+The module adds Micronaut Kafka and the OCI Streaming SDK module, configures Kafka compatibility defaults, and switches Kafka health checks to restricted mode by default when the Kafka health indicator is available and enabled. Restricted health checks verify connectivity without cluster-wide Kafka admin permissions.
 
 For auth-token authentication, configure the stream pool, region, user, and token:
 
@@ -33,4 +35,4 @@ oci:
 
 The supported `auth-mode` values are `auth-token`, `instance-principal`, `resource-principal`, and `user-principal`. For user principals, set `config-file` and `profile` when the default OCI SDK config file or profile should not be used.
 
-The module only fills in Kafka properties that are not already configured. You can override any generated Kafka value under the `kafka` prefix, including `kafka.bootstrap.servers`, `kafka.security.protocol`, `kafka.sasl.mechanism`, and `kafka.sasl.jaas.config`.
+The module only fills in Kafka properties that are not already configured. You can override any generated Kafka value under the `kafka` prefix, including `kafka.bootstrap.servers`, `kafka.security.protocol`, `kafka.sasl.mechanism`, and `kafka.sasl.jaas.config`. Programmatic `KafkaDefaultConfiguration` customizations are also preserved when they run before the OCI Streaming listener.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ functions: Oracle Functions (Serverless)
 httpFunctions: Oracle Functions HTTP (Serverless)
 autonomousDatabase: Oracle Autonomous Database
 micrometer: Micrometer Support For Oracle Monitoring
+streaming: OCI Streaming Support
 tracing: OCI Application Performance Monitoring as a Tracing Endpoint
 logging: OCI Logging service
 vault: Secure Distributed Configuration with Oracle Cloud Vault


### PR DESCRIPTION
## Summary
- add a new `micronaut-oraclecloud-streaming` module that auto-configures Micronaut Kafka for OCI Streaming
- resolve Kafka bootstrap servers from the configured stream pool and default the compatibility-friendly Kafka health check
- document the new module in the guide

Resolves #180