### PR TITLE
Generate ATP wallet password when missing

### DIFF
--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/AutonomousDatabaseConfiguration.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/AutonomousDatabaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.jdbc.BasicJdbcConfiguration;
 
+import java.security.SecureRandom;
+
 /**
  * Configuration properties for the automated oracle wallet download and configuration.
  *
@@ -29,6 +31,17 @@ import io.micronaut.jdbc.BasicJdbcConfiguration;
 @EachProperty(value = BasicJdbcConfiguration.PREFIX, primary = "default")
 @Context
 public class AutonomousDatabaseConfiguration {
+
+    private static final int GENERATED_WALLET_PASSWORD_LENGTH = 32;
+
+    private static final char[] GENERATED_WALLET_PASSWORD_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+
+    private static final char[] GENERATED_WALLET_PASSWORD_NUMBERS = "0123456789".toCharArray();
+
+    private static final char[] GENERATED_WALLET_PASSWORD_CHARS =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private String ocid;
 
@@ -63,6 +76,9 @@ public class AutonomousDatabaseConfiguration {
      * @return wallet password
      */
     public String getWalletPassword() {
+        if (walletPassword == null || walletPassword.isBlank()) {
+            walletPassword = generateWalletPassword();
+        }
         return walletPassword;
     }
 
@@ -113,5 +129,29 @@ public class AutonomousDatabaseConfiguration {
      */
     public void setServiceAliasSuffix(String serviceAliasSuffix) {
         this.serviceAliasSuffix = serviceAliasSuffix;
+    }
+
+    private static String generateWalletPassword() {
+        char[] password = new char[GENERATED_WALLET_PASSWORD_LENGTH];
+        password[0] = randomChar(GENERATED_WALLET_PASSWORD_LETTERS);
+        password[1] = randomChar(GENERATED_WALLET_PASSWORD_NUMBERS);
+        for (int i = 2; i < password.length; i++) {
+            password[i] = randomChar(GENERATED_WALLET_PASSWORD_CHARS);
+        }
+        shuffle(password);
+        return new String(password);
+    }
+
+    private static char randomChar(char[] chars) {
+        return chars[SECURE_RANDOM.nextInt(chars.length)];
+    }
+
+    private static void shuffle(char[] password) {
+        for (int i = password.length - 1; i > 0; i--) {
+            int index = SECURE_RANDOM.nextInt(i + 1);
+            char current = password[index];
+            password[index] = password[i];
+            password[i] = current;
+        }
     }
 }

--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/AutonomousDatabaseConfiguration.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/AutonomousDatabaseConfiguration.java
@@ -32,15 +32,15 @@ import java.security.SecureRandom;
 @Context
 public class AutonomousDatabaseConfiguration {
 
-    private static final int GENERATED_WALLET_SECRET_LENGTH = 32;
+    private static final int GENERATED_WALLET_VALUE_LENGTH = 32;
 
-    private static final int MIN_WALLET_SECRET_LENGTH = 8;
+    private static final int MIN_WALLET_VALUE_LENGTH = 8;
 
-    private static final char[] GENERATED_WALLET_SECRET_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+    private static final char[] ALPHABETIC_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
 
-    private static final char[] GENERATED_WALLET_SECRET_NUMBERS = "0123456789".toCharArray();
+    private static final char[] NUMERIC_CHARS = "0123456789".toCharArray();
 
-    private static final char[] GENERATED_WALLET_SECRET_CHARS =
+    private static final char[] ALPHANUMERIC_CHARS =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
@@ -89,7 +89,7 @@ public class AutonomousDatabaseConfiguration {
      */
     public synchronized void setWalletPassword(String walletPassword) {
         if (walletPassword != null && !walletPassword.isBlank()) {
-            validateConfiguredWalletSecret(walletPassword);
+            validateConfiguredWalletValue(walletPassword);
         }
         this.walletPassword = walletPassword;
     }
@@ -137,18 +137,18 @@ public class AutonomousDatabaseConfiguration {
     }
 
     private static String generateWalletPassword() {
-        char[] password = new char[GENERATED_WALLET_SECRET_LENGTH];
-        password[0] = randomChar(GENERATED_WALLET_SECRET_LETTERS);
-        password[1] = randomChar(GENERATED_WALLET_SECRET_NUMBERS);
+        char[] password = new char[GENERATED_WALLET_VALUE_LENGTH];
+        password[0] = randomChar(ALPHABETIC_CHARS);
+        password[1] = randomChar(NUMERIC_CHARS);
         for (int i = 2; i < password.length; i++) {
-            password[i] = randomChar(GENERATED_WALLET_SECRET_CHARS);
+            password[i] = randomChar(ALPHANUMERIC_CHARS);
         }
         shuffle(password);
         return new String(password);
     }
 
-    private static void validateConfiguredWalletSecret(String walletPassword) {
-        if (walletPassword.length() < MIN_WALLET_SECRET_LENGTH
+    private static void validateConfiguredWalletValue(String walletPassword) {
+        if (walletPassword.length() < MIN_WALLET_VALUE_LENGTH
                 || walletPassword.chars().noneMatch(Character::isLetter)
                 || walletPassword.chars().noneMatch(AutonomousDatabaseConfiguration::isNumberOrSpecialCharacter)) {
             throw new IllegalArgumentException(

--- a/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/AutonomousDatabaseConfiguration.java
+++ b/oraclecloud-atp/src/main/java/io/micronaut/oraclecloud/atp/jdbc/AutonomousDatabaseConfiguration.java
@@ -32,13 +32,15 @@ import java.security.SecureRandom;
 @Context
 public class AutonomousDatabaseConfiguration {
 
-    private static final int GENERATED_WALLET_PASSWORD_LENGTH = 32;
+    private static final int GENERATED_WALLET_SECRET_LENGTH = 32;
 
-    private static final char[] GENERATED_WALLET_PASSWORD_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+    private static final int MIN_WALLET_SECRET_LENGTH = 8;
 
-    private static final char[] GENERATED_WALLET_PASSWORD_NUMBERS = "0123456789".toCharArray();
+    private static final char[] GENERATED_WALLET_SECRET_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
 
-    private static final char[] GENERATED_WALLET_PASSWORD_CHARS =
+    private static final char[] GENERATED_WALLET_SECRET_NUMBERS = "0123456789".toCharArray();
+
+    private static final char[] GENERATED_WALLET_SECRET_CHARS =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
@@ -75,7 +77,7 @@ public class AutonomousDatabaseConfiguration {
     /**
      * @return wallet password
      */
-    public String getWalletPassword() {
+    public synchronized String getWalletPassword() {
         if (walletPassword == null || walletPassword.isBlank()) {
             walletPassword = generateWalletPassword();
         }
@@ -85,7 +87,10 @@ public class AutonomousDatabaseConfiguration {
     /**
      * @param walletPassword wallet password
      */
-    public void setWalletPassword(String walletPassword) {
+    public synchronized void setWalletPassword(String walletPassword) {
+        if (walletPassword != null && !walletPassword.isBlank()) {
+            validateConfiguredWalletSecret(walletPassword);
+        }
         this.walletPassword = walletPassword;
     }
 
@@ -132,14 +137,27 @@ public class AutonomousDatabaseConfiguration {
     }
 
     private static String generateWalletPassword() {
-        char[] password = new char[GENERATED_WALLET_PASSWORD_LENGTH];
-        password[0] = randomChar(GENERATED_WALLET_PASSWORD_LETTERS);
-        password[1] = randomChar(GENERATED_WALLET_PASSWORD_NUMBERS);
+        char[] password = new char[GENERATED_WALLET_SECRET_LENGTH];
+        password[0] = randomChar(GENERATED_WALLET_SECRET_LETTERS);
+        password[1] = randomChar(GENERATED_WALLET_SECRET_NUMBERS);
         for (int i = 2; i < password.length; i++) {
-            password[i] = randomChar(GENERATED_WALLET_PASSWORD_CHARS);
+            password[i] = randomChar(GENERATED_WALLET_SECRET_CHARS);
         }
         shuffle(password);
         return new String(password);
+    }
+
+    private static void validateConfiguredWalletSecret(String walletPassword) {
+        if (walletPassword.length() < MIN_WALLET_SECRET_LENGTH
+                || walletPassword.chars().noneMatch(Character::isLetter)
+                || walletPassword.chars().noneMatch(AutonomousDatabaseConfiguration::isNumberOrSpecialCharacter)) {
+            throw new IllegalArgumentException(
+                    "wallet-password must be at least eight characters long and include at least one letter and one numeric or special character");
+        }
+    }
+
+    private static boolean isNumberOrSpecialCharacter(int character) {
+        return Character.isDigit(character) || (!Character.isLetterOrDigit(character) && !Character.isWhitespace(character));
     }
 
     private static char randomChar(char[] chars) {

--- a/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
+++ b/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
@@ -18,10 +18,13 @@ package io.micronaut.oraclecloud.atp.jdbc;
 import com.oracle.bmc.database.Database;
 import com.oracle.bmc.database.requests.GenerateAutonomousDatabaseWalletRequest;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Proxy;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,6 +70,28 @@ class OracleWalletArchiveProviderTest {
     }
 
     @ParameterizedTest
+    @MethodSource("invalidConfiguredWalletPasswordCases")
+    void rejectsInvalidConfiguredWalletPassword(String configuredPassword) {
+        AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
+
+        assertThrows(IllegalArgumentException.class, () -> cfg.setWalletPassword(configuredPassword));
+    }
+
+    @ParameterizedTest
+    @MethodSource("missingWalletPasswordCases")
+    void generatesSameWalletPasswordForConcurrentAccess(String configuredPassword) {
+        AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
+        cfg.setWalletPassword(configuredPassword);
+
+        Set<String> walletPasswords = IntStream.range(0, 64)
+            .parallel()
+            .mapToObj(i -> cfg.getWalletPassword())
+            .collect(Collectors.toSet());
+
+        assertEquals(1, walletPasswords.size());
+    }
+
+    @ParameterizedTest
     @MethodSource("missingWalletPasswordCases")
     void sendsGeneratedWalletPasswordToWalletRequest(String configuredPassword) {
         AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
@@ -97,8 +122,17 @@ class OracleWalletArchiveProviderTest {
     private static Stream<Arguments> configuredWalletPasswordCases() {
         return Stream.of(
             Arguments.of("micronaut.1"),
-            Arguments.of("short1"),
+            Arguments.of("micronaut!"),
             Arguments.of("abcdefghijklmnopqrstuvwxyz123456")
+        );
+    }
+
+    private static Stream<Arguments> invalidConfiguredWalletPasswordCases() {
+        return Stream.of(
+            Arguments.of("short1"),
+            Arguments.of("abcdefgh"),
+            Arguments.of("12345678"),
+            Arguments.of("abcdefg ")
         );
     }
 

--- a/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
+++ b/oraclecloud-atp/src/test/java/io/micronaut/oraclecloud/atp/jdbc/OracleWalletArchiveProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,20 @@
  */
 package io.micronaut.oraclecloud.atp.jdbc;
 
+import com.oracle.bmc.database.Database;
+import com.oracle.bmc.database.requests.GenerateAutonomousDatabaseWalletRequest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
 
+import java.lang.reflect.Proxy;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OracleWalletArchiveProviderTest {
 
@@ -36,11 +43,86 @@ class OracleWalletArchiveProviderTest {
         assertEquals(expected, result);
     }
 
+    @ParameterizedTest
+    @MethodSource("missingWalletPasswordCases")
+    void generatesWalletPasswordWhenNotConfigured(String configuredPassword) {
+        AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
+        cfg.setWalletPassword(configuredPassword);
+
+        String walletPassword = cfg.getWalletPassword();
+
+        assertSame(walletPassword, cfg.getWalletPassword());
+        assertEquals(32, walletPassword.length());
+        assertTrue(walletPassword.matches(".*[A-Za-z].*"));
+        assertTrue(walletPassword.matches(".*[0-9].*"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("configuredWalletPasswordCases")
+    void preservesConfiguredWalletPassword(String configuredPassword) {
+        AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
+        cfg.setWalletPassword(configuredPassword);
+
+        assertEquals(configuredPassword, cfg.getWalletPassword());
+    }
+
+    @ParameterizedTest
+    @MethodSource("missingWalletPasswordCases")
+    void sendsGeneratedWalletPasswordToWalletRequest(String configuredPassword) {
+        AutonomousDatabaseConfiguration cfg = new AutonomousDatabaseConfiguration();
+        cfg.setOcid("ocid1.autonomousdatabase.oc1..example");
+        cfg.setServiceAlias("example_high");
+        cfg.setWalletPassword(configuredPassword);
+        OracleWalletArchiveProvider provider = new OracleWalletArchiveProvider(databaseCapturingWalletRequest());
+
+        assertThrows(ExpectedRequestCapturedException.class, () -> provider.loadWalletArchive(cfg));
+    }
+
     private static Stream<Arguments> aliasCases() {
         return Stream.of(
             Arguments.of(null, null, "mydb", "mydb_high"),
             Arguments.of(null, "tp", "mydb", "mydb_tp"),
             Arguments.of("custom_alias", "tp", "mydb", "custom_alias")
         );
+    }
+
+    private static Stream<Arguments> missingWalletPasswordCases() {
+        return Stream.of(
+            Arguments.of((String) null),
+            Arguments.of(""),
+            Arguments.of("   ")
+        );
+    }
+
+    private static Stream<Arguments> configuredWalletPasswordCases() {
+        return Stream.of(
+            Arguments.of("micronaut.1"),
+            Arguments.of("short1"),
+            Arguments.of("abcdefghijklmnopqrstuvwxyz123456")
+        );
+    }
+
+    private static Database databaseCapturingWalletRequest() {
+        return (Database) Proxy.newProxyInstance(
+            Database.class.getClassLoader(),
+            new Class<?>[] { Database.class },
+            (proxy, method, args) -> {
+                if ("generateAutonomousDatabaseWallet".equals(method.getName())) {
+                    GenerateAutonomousDatabaseWalletRequest request = (GenerateAutonomousDatabaseWalletRequest) args[0];
+                    String password = request.getGenerateAutonomousDatabaseWalletDetails().getPassword();
+                    assertNotNull(password);
+                    assertEquals(32, password.length());
+                    assertTrue(password.matches(".*[A-Za-z].*"));
+                    assertTrue(password.matches(".*[0-9].*"));
+                    throw new ExpectedRequestCapturedException();
+                }
+                if ("toString".equals(method.getName())) {
+                    return "Database proxy";
+                }
+                throw new UnsupportedOperationException(method.getName());
+            });
+    }
+
+    private static final class ExpectedRequestCapturedException extends RuntimeException {
     }
 }

--- a/src/main/docs/guide/autonomousDatabase.adoc
+++ b/src/main/docs/guide/autonomousDatabase.adoc
@@ -58,7 +58,7 @@ datasources:
     password: bar
 ----
 - `ocid` specifies the Autonomous Database id
-- `wallet-password` is optional; it encrypts the keys inside the wallet. If it is not set, Micronaut automatically generates one. If set, it must be at least eight characters long, include at least one letter, and either one numeric character or one special character.
+- `wallet-password` is optional; it encrypts the keys inside the wallet. If it is not set or is blank, Micronaut automatically generates one. If set, it must be at least eight characters long, include at least one letter, and either one numeric character or one special character.
 - specify the database `username` and `password`
 - optionally `service-alias-suffix` controls the suffix used when computing the default service alias using database name and given service alias suffix; defaults to `high` (e.g., set to `tp`)
 

--- a/src/main/docs/guide/autonomousDatabase.adoc
+++ b/src/main/docs/guide/autonomousDatabase.adoc
@@ -54,12 +54,11 @@ To use automated data source configuration from the Wallet, provide a configurat
 datasources:
   default:
     ocid: ocid1.autonomousdatabase.oc1.....
-    walletPassword: micronaut.1
     username: foo
     password: bar
 ----
 - `ocid` specifies the Autonomous Database id
-- `wallet-password` encrypts the keys inside the wallet. It must be at least eight characters long, include at least one letter, and either one numeric character or one special character)
+- `wallet-password` is optional; it encrypts the keys inside the wallet. If it is not set, Micronaut automatically generates one. If set, it must be at least eight characters long, include at least one letter, and either one numeric character or one special character.
 - specify the database `username` and `password`
 - optionally `service-alias-suffix` controls the suffix used when computing the default service alias using database name and given service alias suffix; defaults to `high` (e.g., set to `tp`)
 


### PR DESCRIPTION
## Summary
- Generate an ATP wallet password when `wallet-password` is not configured or is blank.
- Reuse the generated password for the wallet request and preserve explicitly configured passwords.
- Update the Autonomous Database guide to document the optional password behavior.

## Testing
- `./gradlew :micronaut-oraclecloud-atp:test --tests io.micronaut.oraclecloud.atp.jdbc.OracleWalletArchiveProviderTest -q`

Resolves https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/330
