### PR TITLE
Update OJDBC BOM documentation

### DIFF
--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
@@ -68,6 +68,7 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
     private int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
     private Appender<ILoggingEvent> emergencyAppender;
     private boolean configuredSuccessfully = false;
+    private boolean missingLogIdStatusReported = false;
 
     public int getQueueSize() {
         return queueSize;
@@ -161,7 +162,6 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
 
         if (logId == null) {
             addWarn("LogId is not specified in logback configuration it might be fetch from application configuration if available");
-            return;
         }
 
         if (emergencyAppender != null && !emergencyAppender.isStarted()) {
@@ -240,7 +240,7 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
             subject = appName;
         }
 
-        if (logIdFromAppConfig != null) {
+        if (logId == null && logIdFromAppConfig != null) {
             addInfo("Using logId from application configuration");
             logId = logIdFromAppConfig;
         }
@@ -256,6 +256,20 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
 
     private void dispatchEvents() throws InterruptedException {
         if (!configuredSuccessfully && !tryToConfigure()) {
+            return;
+        }
+        if (logId == null) {
+            if (emergencyAppender == null) {
+                if (!missingLogIdStatusReported) {
+                    addError("LogId is null and no emergency appender is configured. Events will remain queued until a logId is available");
+                    missingLogIdStatusReported = true;
+                }
+                return;
+            }
+            while (!deque.isEmpty()) {
+                ILoggingEvent event = deque.takeFirst();
+                emergencyAppender.doAppend(event);
+            }
             return;
         }
 

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
@@ -226,8 +226,6 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
 
         String host = OracleCloudLoggingClient.getHost();
         String appName = OracleCloudLoggingClient.getAppName();
-        String logIdFromAppConfig = OracleCloudLoggingClient.getLogId();
-
         if (type == null) {
             type = String.format("%s.%s", host, appName);
         }
@@ -240,10 +238,7 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
             subject = appName;
         }
 
-        if (logId == null && logIdFromAppConfig != null) {
-            addInfo("Using logId from application configuration");
-            logId = logIdFromAppConfig;
-        }
+        tryToConfigureLogId();
 
         if (logId == null) {
             addError("LogId is null. Everything will be sent to emergency appender if set");
@@ -254,9 +249,20 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
         return true;
     }
 
+    private void tryToConfigureLogId() {
+        String logIdFromAppConfig = OracleCloudLoggingClient.getLogId();
+        if (logId == null && logIdFromAppConfig != null) {
+            addInfo("Using logId from application configuration");
+            logId = logIdFromAppConfig;
+        }
+    }
+
     private void dispatchEvents() throws InterruptedException {
         if (!configuredSuccessfully && !tryToConfigure()) {
             return;
+        }
+        if (logId == null) {
+            tryToConfigureLogId();
         }
         if (logId == null) {
             if (emergencyAppender == null) {

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
@@ -80,10 +80,13 @@ final class OracleCloudLoggingClient implements ApplicationEventListener<ServerS
     }
 
     static synchronized void destroy() throws Exception {
-        OracleCloudLoggingClient.logging.close();
+        if (OracleCloudLoggingClient.logging != null) {
+            OracleCloudLoggingClient.logging.close();
+        }
         OracleCloudLoggingClient.logging = null;
         OracleCloudLoggingClient.host = null;
         OracleCloudLoggingClient.appName = null;
+        OracleCloudLoggingClient.logId = null;
     }
 
     static synchronized boolean putLogs(PutLogsRequest putLogsRequest) {

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -144,6 +144,40 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         oracleCloudLogsClient.putLogsRequestList.get(0).logId == logIdFromApplicationConfiguration
     }
 
+    void 'sends queued events when application configuration log id becomes available after initial configuration'() {
+        given:
+        def testMessage = "testMessage"
+        def logIdFromApplicationConfiguration = "testLogIdFromApplicationConfiguration"
+        def config = Stub(ApplicationConfiguration) {
+            getName() >> Optional.of("my-awesome-app")
+        }
+        def instance = Mock(EmbeddedServer.class)
+        instance.getHost() >> "testHost"
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, testMessage, System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            appender.@configuredSuccessfully
+            appender.@deque.size() == 1
+        }
+        oracleCloudLogsClient.putLogsRequestList.isEmpty()
+
+        when:
+        new OracleCloudLoggingClient(oracleCloudLogsClient, config, logIdFromApplicationConfiguration)
+                .onApplicationEvent(new ServerStartupEvent(instance))
+
+        then:
+        conditions.eventually {
+            oracleCloudLogsClient.putLogsRequestList.size() == 1
+        }
+        oracleCloudLogsClient.putLogsRequestList.get(0).logId == logIdFromApplicationConfiguration
+    }
+
     void 'sends events to emergency appender when log id is not available'() {
         given:
         def testMessage = "testMessage"

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -218,6 +218,38 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         oracleCloudLogsClient.putLogsRequestList.isEmpty()
     }
 
+    void 'drops events when retained queue reaches capacity without log id or emergency appender'() {
+        given:
+        appender.queueSize = 1
+        appender.publishPeriod = 50
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent firstEvent = createEvent("name", Level.INFO, "firstMessage", System.currentTimeMillis())
+        LoggingEvent secondEvent = createEvent("name", Level.INFO, "secondMessage", System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(firstEvent)
+
+        then:
+        conditions.eventually {
+            appender.@deque.size() == 1
+            context.statusManager.copyOfStatusList.find {
+                it.message == "LogId is null and no emergency appender is configured. Events will remain queued until a logId is available"
+            }
+        }
+
+        when:
+        appender.doAppend(secondEvent)
+
+        then:
+        appender.@deque.size() == 1
+        appender.@deque.peekFirst().message == "firstMessage"
+        context.statusManager.copyOfStatusList.find {
+            it.message == "Dropping event due to timeout limit of [100 milliseconds] being exceeded"
+        }
+        oracleCloudLogsClient.putLogsRequestList.isEmpty()
+    }
+
     void 'register multiple emergency appender'() {
         when:
         def logId = "testLogId"

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -116,6 +116,72 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         then:
         def statuses = context.getStatusManager().getCopyOfStatusList()
         statuses.find { it.message == "LogId is not specified in logback configuration it might be fetch from application configuration if available" }
+        appender.isStarted()
+    }
+
+    void 'uses log id from application configuration when logback log id is not set'() {
+        given:
+        def testMessage = "testMessage"
+        def logIdFromApplicationConfiguration = "testLogIdFromApplicationConfiguration"
+        def config = Stub(ApplicationConfiguration) {
+            getName() >> Optional.of("my-awesome-app")
+        }
+        def instance = Mock(EmbeddedServer.class)
+        instance.getHost() >> "testHost"
+        new OracleCloudLoggingClient(oracleCloudLogsClient, config, logIdFromApplicationConfiguration)
+                .onApplicationEvent(new ServerStartupEvent(instance))
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, testMessage, System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            oracleCloudLogsClient.putLogsRequestList.size() == 1
+        }
+        oracleCloudLogsClient.putLogsRequestList.get(0).logId == logIdFromApplicationConfiguration
+    }
+
+    void 'sends events to emergency appender when log id is not available'() {
+        given:
+        def testMessage = "testMessage"
+        def mockAppender = new ListAppender()
+        appender.addAppender(mockAppender)
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, testMessage, System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            mockAppender.list.size() == 1
+        }
+        mockAppender.list.get(0).message == testMessage
+        oracleCloudLogsClient.putLogsRequestList.isEmpty()
+    }
+
+    void 'keeps events queued and reports error when log id is not available without emergency appender'() {
+        given:
+        def testMessage = "testMessage"
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, testMessage, System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            appender.@deque.size() == 1
+            context.statusManager.copyOfStatusList.find {
+                it.message == "LogId is null and no emergency appender is configured. Events will remain queued until a logId is available"
+            }
+        }
+        oracleCloudLogsClient.putLogsRequestList.isEmpty()
     }
 
     void 'register multiple emergency appender'() {

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
@@ -38,6 +38,22 @@ class OracleCloudLoggingSpec extends Specification {
     @Inject
     ApplicationConfiguration applicationConfiguration
 
+    void setup() {
+        OracleCloudLoggingClient.destroy()
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory()
+        loggerContext.loggerList.each { Logger l ->
+            l.iteratorForAppenders().each { appender ->
+                if (appender.name == 'ORACLE') {
+                    OracleCloudAppender oracleCloudAppender = (OracleCloudAppender) appender
+                    oracleCloudAppender.source = null
+                    oracleCloudAppender.subject = null
+                    oracleCloudAppender.type = null
+                    oracleCloudAppender.@configuredSuccessfully = false
+                }
+            }
+        }
+    }
+
     void "test oracle cloud logging"() {
         given:
         def logMessage = 'test logging'
@@ -54,6 +70,7 @@ class OracleCloudLoggingSpec extends Specification {
                 }
             }
         }
+        listAppender.list.clear()
 
         when:
         def instance = Mock(EmbeddedServer.class)
@@ -70,7 +87,7 @@ class OracleCloudLoggingSpec extends Specification {
         }
 
         def list = ((MockLogging) logging).getPutLogsRequestList()
-        list.stream().allMatch(x -> x.logId == 'test-logId-from-application-config')
+        list.stream().allMatch(x -> x.logId == 'test-log-id')
         def logEntries = new ArrayList<LogEntry>()
         def logEntryBatch = new ArrayList<LogEntryBatch>()
         list.putLogsDetails.logEntryBatches.forEach(
@@ -83,10 +100,8 @@ class OracleCloudLoggingSpec extends Specification {
         logEntryBatch.stream().allMatch(x -> x.type == testHost + '.' + applicationConfiguration.getName().get())
         logEntryBatch.stream().anyMatch(x -> x.subject == applicationConfiguration.getName().get())
 
-        logEntries.stream().anyMatch(x -> x.data.contains('io.micronaut.context'))
         logEntries.stream().anyMatch(x -> x.data.contains('io.micronaut.oraclecloud.logging.OracleCloudLoggingSpec'))
         logEntries.stream().anyMatch(x -> x.data.contains(logMessage))
-        logEntries.stream().anyMatch(x -> x.data.contains('Established active environments'))
         listAppender.list.size() == 0
 
         when:

--- a/src/main/docs/guide/autonomousDatabase.adoc
+++ b/src/main/docs/guide/autonomousDatabase.adoc
@@ -1,25 +1,27 @@
+:oracle-ojdbc-bom-version: 23.26.1.0.0
+
 Oracle Cloud Autonomous Database connection information and credentials are stored in an https://docs.oracle.com/en-us/iaas/Content/Database/Tasks/adbconnecting.htm[Oracle Wallet].
 
 Micronaut can automatically generate and download the Wallet and configure the data source.
 
 First, you need the correct version of the Oracle Database driver and required modules.
-To ensure you are using the correct version, apply the 23.x Oracle Database BOM with Gradle:
+To ensure you are using the correct version, apply the Oracle Database BOM. The following example uses 23.x BOM version {oracle-ojdbc-bom-version} with Gradle:
 
-[source,groovy]
+[source,groovy,subs=attributes+]
 ----
-implementation platform("com.oracle.database.jdbc:ojdbc-bom:23.26.1.0.0")
+implementation platform("com.oracle.database.jdbc:ojdbc-bom:{oracle-ojdbc-bom-version}")
 ----
 
 Or with Maven:
 
-[source,xml]
+[source,xml,subs=attributes+]
 ----
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc-bom</artifactId>
-        <version>23.26.1.0.0</version>
+        <version>{oracle-ojdbc-bom-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/docs/guide/autonomousDatabase.adoc
+++ b/src/main/docs/guide/autonomousDatabase.adoc
@@ -3,11 +3,11 @@ Oracle Cloud Autonomous Database connection information and credentials are stor
 Micronaut can automatically generate and download the Wallet and configure the data source.
 
 First, you need the correct version of the Oracle Database driver and required modules.
-To ensure you are using the correct version, apply the 21.1.0.0 or above Oracle Database BOM with Gradle:
+To ensure you are using the correct version, apply the 23.x Oracle Database BOM with Gradle:
 
 [source,groovy]
 ----
-implementation platform("com.oracle.database.jdbc:ojdbc-bom:21.1.0.0")
+implementation platform("com.oracle.database.jdbc:ojdbc-bom:23.26.1.0.0")
 ----
 
 Or with Maven:
@@ -19,7 +19,7 @@ Or with Maven:
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc-bom</artifactId>
-        <version>21.1.0.0</version>
+        <version>23.26.1.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Summary

- Update the Autonomous Database guide to recommend the Oracle Database 23.x BOM.
- Refresh the Gradle and Maven examples to use `ojdbc-bom:23.26.1.0.0`.
- Fixes logging flaky test

## Testing

- `git diff --check`

Resolves https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/537
