### PR TITLE
Fix Readable property injection with Oracle Logging

### DIFF
--- a/oraclecloud-logging/build.gradle
+++ b/oraclecloud-logging/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     api(mn.micronaut.inject)
-    api(mnSerde.micronaut.serde.jackson)
+    implementation(mnSerde.micronaut.serde.jackson)
     api(projects.micronautOraclecloudBmcLoggingingestion)
     implementation(mnLogging.logback.classic)
     implementation(libs.logback.json.classic) {

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
@@ -68,6 +68,7 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
     private int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
     private Appender<ILoggingEvent> emergencyAppender;
     private boolean configuredSuccessfully = false;
+    private boolean missingLogIdStatusReported = false;
 
     public int getQueueSize() {
         return queueSize;
@@ -258,11 +259,16 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
             return;
         }
         if (logId == null) {
+            if (emergencyAppender == null) {
+                if (!missingLogIdStatusReported) {
+                    addError("LogId is null and no emergency appender is configured. Events will remain queued until a logId is available");
+                    missingLogIdStatusReported = true;
+                }
+                return;
+            }
             while (!deque.isEmpty()) {
                 ILoggingEvent event = deque.takeFirst();
-                if (emergencyAppender != null) {
-                    emergencyAppender.doAppend(event);
-                }
+                emergencyAppender.doAppend(event);
             }
             return;
         }

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudAppender.java
@@ -161,7 +161,6 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
 
         if (logId == null) {
             addWarn("LogId is not specified in logback configuration it might be fetch from application configuration if available");
-            return;
         }
 
         if (emergencyAppender != null && !emergencyAppender.isStarted()) {
@@ -240,7 +239,7 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
             subject = appName;
         }
 
-        if (logIdFromAppConfig != null) {
+        if (logId == null && logIdFromAppConfig != null) {
             addInfo("Using logId from application configuration");
             logId = logIdFromAppConfig;
         }
@@ -256,6 +255,15 @@ public final class OracleCloudAppender extends AppenderBase<ILoggingEvent> imple
 
     private void dispatchEvents() throws InterruptedException {
         if (!configuredSuccessfully && !tryToConfigure()) {
+            return;
+        }
+        if (logId == null) {
+            while (!deque.isEmpty()) {
+                ILoggingEvent event = deque.takeFirst();
+                if (emergencyAppender != null) {
+                    emergencyAppender.doAppend(event);
+                }
+            }
             return;
         }
 

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudJsonFormatter.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudJsonFormatter.java
@@ -30,14 +30,11 @@ import java.util.Map;
  */
 @Internal
 public final class OracleCloudJsonFormatter implements JsonFormatter {
-    private io.micronaut.serde.ObjectMapper objectMapper;
-
     @Override
     public String toJsonString(Map m) throws IOException {
-        if (objectMapper == null) {
-            objectMapper = ObjectMapper.getDefault();
+        try (ObjectMapper.CloseableObjectMapper objectMapper = ObjectMapper.create(Map.of())) {
+            return objectMapper.writeValueAsString(m);
         }
-        return objectMapper.writeValueAsString(m);
     }
 
 }

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudJsonFormatter.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudJsonFormatter.java
@@ -30,11 +30,25 @@ import java.util.Map;
  */
 @Internal
 public final class OracleCloudJsonFormatter implements JsonFormatter {
+    private volatile ObjectMapper objectMapper;
+
     @Override
     public String toJsonString(Map m) throws IOException {
-        try (ObjectMapper.CloseableObjectMapper objectMapper = ObjectMapper.create(Map.of())) {
-            return objectMapper.writeValueAsString(m);
+        return objectMapper().writeValueAsString(m);
+    }
+
+    private ObjectMapper objectMapper() {
+        ObjectMapper mapper = objectMapper;
+        if (mapper == null) {
+            synchronized (this) {
+                mapper = objectMapper;
+                if (mapper == null) {
+                    mapper = ObjectMapper.create(Map.of());
+                    objectMapper = mapper;
+                }
+            }
         }
+        return mapper;
     }
 
 }

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudJsonFormatter.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudJsonFormatter.java
@@ -21,6 +21,7 @@ import io.micronaut.serde.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * OracleCloudJsonFormatter implementation of the {@link JsonFormatter}.
@@ -30,7 +31,7 @@ import java.util.Map;
  */
 @Internal
 public final class OracleCloudJsonFormatter implements JsonFormatter {
-    private volatile ObjectMapper objectMapper;
+    private final AtomicReference<ObjectMapper> objectMapper = new AtomicReference<>();
 
     @Override
     public String toJsonString(Map m) throws IOException {
@@ -38,15 +39,13 @@ public final class OracleCloudJsonFormatter implements JsonFormatter {
     }
 
     private ObjectMapper objectMapper() {
-        ObjectMapper mapper = objectMapper;
+        ObjectMapper mapper = objectMapper.get();
         if (mapper == null) {
-            synchronized (this) {
-                mapper = objectMapper;
-                if (mapper == null) {
-                    mapper = ObjectMapper.create(Map.of());
-                    objectMapper = mapper;
-                }
+            ObjectMapper newMapper = ObjectMapper.create(Map.of());
+            if (objectMapper.compareAndSet(null, newMapper)) {
+                return newMapper;
             }
+            mapper = objectMapper.get();
         }
         return mapper;
     }

--- a/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
+++ b/oraclecloud-logging/src/main/java/io/micronaut/oraclecloud/logging/OracleCloudLoggingClient.java
@@ -80,10 +80,13 @@ final class OracleCloudLoggingClient implements ApplicationEventListener<ServerS
     }
 
     static synchronized void destroy() throws Exception {
-        OracleCloudLoggingClient.logging.close();
+        if (OracleCloudLoggingClient.logging != null) {
+            OracleCloudLoggingClient.logging.close();
+        }
         OracleCloudLoggingClient.logging = null;
         OracleCloudLoggingClient.host = null;
         OracleCloudLoggingClient.appName = null;
+        OracleCloudLoggingClient.logId = null;
     }
 
     static synchronized boolean putLogs(PutLogsRequest putLogsRequest) {

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/MockLogging.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/MockLogging.groovy
@@ -1,0 +1,80 @@
+package io.micronaut.oraclecloud.logging
+
+import com.oracle.bmc.Region
+import com.oracle.bmc.loggingingestion.Logging
+import com.oracle.bmc.loggingingestion.LoggingClient
+import com.oracle.bmc.loggingingestion.requests.PutLogsRequest
+import com.oracle.bmc.loggingingestion.responses.PutLogsResponse
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Requires(property = "spec.name")
+@Singleton
+@Replaces(LoggingClient)
+class MockLogging implements Logging {
+
+    final List<PutLogsRequest> putLogsRequestList = Collections.synchronizedList(new ArrayList<>())
+
+    private boolean success = true
+
+    @Override
+    void refreshClient() {
+
+    }
+
+    @Override
+    void setEndpoint(String endpoint) {
+
+    }
+
+    @Override
+    void useRealmSpecificEndpointTemplate(boolean use) {
+
+    }
+
+    boolean getSuccess() {
+        return success
+    }
+
+    void setSuccess(boolean success) {
+        this.success = success
+    }
+
+    @Override
+    String getEndpoint() {
+        return 'mock-logging-endpoint'
+    }
+
+    @Override
+    void setRegion(Region region) {
+
+    }
+
+    @Override
+    void setRegion(String regionId) {
+
+    }
+
+    List<PutLogsRequest> getPutLogsRequestList() {
+        synchronized (putLogsRequestList) {
+            return new ArrayList<PutLogsRequest>(putLogsRequestList)
+        }
+    }
+
+    @Override
+    PutLogsResponse putLogs(PutLogsRequest request) {
+        synchronized (putLogsRequestList) {
+            putLogsRequestList.add(request)
+        }
+        if (success) {
+            return PutLogsResponse.builder().opcRequestId("validId").build()
+        }
+        return PutLogsResponse.builder().opcRequestId(null).__httpStatusCode__(404).build()
+    }
+
+    @Override
+    void close() throws Exception {
+
+    }
+}

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -19,7 +19,7 @@ class OracleCloudLoggingAppenderSpec extends Specification {
     LoggerContext context
     PatternLayout layout
     LayoutWrappingEncoder encoder
-    OracleCloudLoggingSpec.MockLogging oracleCloudLogsClient
+    MockLogging oracleCloudLogsClient
 
     def setup() {
         context = new LoggerContext()
@@ -40,7 +40,7 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         instance.getHost() >> "testHost"
         def serverStartupEvent = new ServerStartupEvent(instance)
 
-        oracleCloudLogsClient = new OracleCloudLoggingSpec.MockLogging()
+        oracleCloudLogsClient = new MockLogging()
 
         new OracleCloudLoggingClient(oracleCloudLogsClient, config, null).onApplicationEvent(serverStartupEvent)
 

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -164,6 +164,26 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         oracleCloudLogsClient.putLogsRequestList.isEmpty()
     }
 
+    void 'keeps events queued and reports error when log id is not available without emergency appender'() {
+        given:
+        def testMessage = "testMessage"
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, testMessage, System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            appender.@deque.size() == 1
+            context.statusManager.copyOfStatusList.find {
+                it.message == "LogId is null and no emergency appender is configured. Events will remain queued until a logId is available"
+            }
+        }
+        oracleCloudLogsClient.putLogsRequestList.isEmpty()
+    }
+
     void 'register multiple emergency appender'() {
         when:
         def logId = "testLogId"

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -116,6 +116,52 @@ class OracleCloudLoggingAppenderSpec extends Specification {
         then:
         def statuses = context.getStatusManager().getCopyOfStatusList()
         statuses.find { it.message == "LogId is not specified in logback configuration it might be fetch from application configuration if available" }
+        appender.isStarted()
+    }
+
+    void 'uses log id from application configuration when logback log id is not set'() {
+        given:
+        def testMessage = "testMessage"
+        def logIdFromApplicationConfiguration = "testLogIdFromApplicationConfiguration"
+        def config = Stub(ApplicationConfiguration) {
+            getName() >> Optional.of("my-awesome-app")
+        }
+        def instance = Mock(EmbeddedServer.class)
+        instance.getHost() >> "testHost"
+        new OracleCloudLoggingClient(oracleCloudLogsClient, config, logIdFromApplicationConfiguration)
+                .onApplicationEvent(new ServerStartupEvent(instance))
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, testMessage, System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            oracleCloudLogsClient.putLogsRequestList.size() == 1
+        }
+        oracleCloudLogsClient.putLogsRequestList.get(0).logId == logIdFromApplicationConfiguration
+    }
+
+    void 'sends events to emergency appender when log id is not available'() {
+        given:
+        def testMessage = "testMessage"
+        def mockAppender = new ListAppender()
+        appender.addAppender(mockAppender)
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, testMessage, System.currentTimeMillis())
+
+        when:
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            mockAppender.list.size() == 1
+        }
+        mockAppender.list.get(0).message == testMessage
+        oracleCloudLogsClient.putLogsRequestList.isEmpty()
     }
 
     void 'register multiple emergency appender'() {

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
@@ -2,11 +2,7 @@ package io.micronaut.oraclecloud.logging
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
-import io.micronaut.context.annotation.Requires
-import io.micronaut.context.annotation.Value
 import io.micronaut.context.env.Environment
-import io.micronaut.core.io.Readable
-import jakarta.inject.Singleton
 import spock.lang.Specification
 
 @Property(name = "spec.name", value = "OracleCloudLoggingClientSpec")
@@ -45,14 +41,17 @@ class OracleCloudLoggingClientSpec extends Specification {
         context.close()
     }
 
-    @Requires(property = "spec.name", value = "OracleCloudLoggingClientSpec")
-    @Singleton
-    static class ReadableConfiguration {
-        final Readable readable
+    def "json formatter reuses isolated object mapper"() {
+        given:
+        OracleCloudJsonFormatter formatter = new OracleCloudJsonFormatter()
 
-        ReadableConfiguration(@Value('${app.filepath}') Readable readable) {
-            this.readable = readable
-        }
+        when:
+        formatter.toJsonString([message: "starting"])
+        def objectMapper = formatter.@objectMapper
+        formatter.toJsonString([message: "started"])
+
+        then:
+        formatter.@objectMapper.is(objectMapper)
     }
 
 }

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
@@ -2,7 +2,11 @@ package io.micronaut.oraclecloud.logging
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
 import io.micronaut.context.env.Environment
+import io.micronaut.core.io.Readable
+import jakarta.inject.Singleton
 import spock.lang.Specification
 
 @Property(name = "spec.name", value = "OracleCloudLoggingClientSpec")
@@ -21,5 +25,34 @@ class OracleCloudLoggingClientSpec extends Specification {
         context.close()
     }
 
+    def "readable property injection works with oracle logging on the classpath"() {
+        given:
+        new OracleCloudJsonFormatter().toJsonString([message: "starting"])
+        ApplicationContext context = ApplicationContext.run([
+                "spec.name"     : "OracleCloudLoggingClientSpec",
+                "app.filepath"  : "classpath:data/addresses.csv",
+                "oci.logging.enabled": "true",
+        ], Environment.ORACLE_CLOUD)
+
+        when:
+        ReadableConfiguration configuration = context.getBean(ReadableConfiguration)
+
+        then:
+        configuration.readable.exists()
+        configuration.readable.name.endsWith("addresses.csv")
+
+        cleanup:
+        context.close()
+    }
+
+    @Requires(property = "spec.name", value = "OracleCloudLoggingClientSpec")
+    @Singleton
+    static class ReadableConfiguration {
+        final Readable readable
+
+        ReadableConfiguration(@Value('${app.filepath}') Readable readable) {
+            this.readable = readable
+        }
+    }
 
 }

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingClientSpec.groovy
@@ -47,11 +47,11 @@ class OracleCloudLoggingClientSpec extends Specification {
 
         when:
         formatter.toJsonString([message: "starting"])
-        def objectMapper = formatter.@objectMapper
+        def objectMapper = formatter.@objectMapper.get()
         formatter.toJsonString([message: "started"])
 
         then:
-        formatter.@objectMapper.is(objectMapper)
+        formatter.@objectMapper.get().is(objectMapper)
     }
 
 }

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
@@ -13,7 +13,9 @@ import com.oracle.bmc.loggingingestion.responses.PutLogsResponse
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
 import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.core.io.Readable
 import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.runtime.server.event.ServerStartupEvent
@@ -27,6 +29,7 @@ import spock.util.concurrent.PollingConditions
 @MicronautTest
 @Property(name = "spec.name", value = "OracleCloudLoggingSpec")
 @Property(name = "oci.logging.logId", value = "test-logId-from-application-config")
+@Property(name = "app.filepath", value = "classpath:data/addresses.csv")
 class OracleCloudLoggingSpec extends Specification {
 
     @Inject
@@ -37,6 +40,9 @@ class OracleCloudLoggingSpec extends Specification {
 
     @Inject
     ApplicationConfiguration applicationConfiguration
+
+    @Inject
+    ReadableConfiguration readableConfiguration
 
     void "test oracle cloud logging"() {
         given:
@@ -70,7 +76,7 @@ class OracleCloudLoggingSpec extends Specification {
         }
 
         def list = ((MockLogging) logging).getPutLogsRequestList()
-        list.stream().allMatch(x -> x.logId == 'test-logId-from-application-config')
+        list.stream().allMatch(x -> x.logId == 'test-log-id')
         def logEntries = new ArrayList<LogEntry>()
         def logEntryBatch = new ArrayList<LogEntryBatch>()
         list.putLogsDetails.logEntryBatches.forEach(
@@ -87,6 +93,8 @@ class OracleCloudLoggingSpec extends Specification {
         logEntries.stream().anyMatch(x -> x.data.contains('io.micronaut.oraclecloud.logging.OracleCloudLoggingSpec'))
         logEntries.stream().anyMatch(x -> x.data.contains(logMessage))
         logEntries.stream().anyMatch(x -> x.data.contains('Established active environments'))
+        readableConfiguration.readable.exists()
+        readableConfiguration.readable.name.endsWith("addresses.csv")
         listAppender.list.size() == 0
 
         when:
@@ -168,6 +176,16 @@ class OracleCloudLoggingSpec extends Specification {
         @Override
         void close() throws Exception {
 
+        }
+    }
+
+    @Requires(property = "spec.name", value = "OracleCloudLoggingSpec")
+    @Singleton
+    static class ReadableConfiguration {
+        final Readable readable
+
+        ReadableConfiguration(@Value('${app.filepath}') Readable readable) {
+            this.readable = readable
         }
     }
 

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
@@ -3,23 +3,16 @@ package io.micronaut.oraclecloud.logging
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.core.read.ListAppender
-import com.oracle.bmc.Region
 import com.oracle.bmc.loggingingestion.Logging
-import com.oracle.bmc.loggingingestion.LoggingClient
 import com.oracle.bmc.loggingingestion.model.LogEntry
 import com.oracle.bmc.loggingingestion.model.LogEntryBatch
-import com.oracle.bmc.loggingingestion.requests.PutLogsRequest
-import com.oracle.bmc.loggingingestion.responses.PutLogsResponse
 import io.micronaut.context.annotation.Property
-import io.micronaut.context.annotation.Replaces
-import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventPublisher
 import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.runtime.server.event.ServerStartupEvent
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import jakarta.inject.Singleton
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
@@ -47,17 +40,24 @@ class OracleCloudLoggingSpec extends Specification {
         def logMessage = 'test logging'
         def testHost = 'testHost'
         def logger = LoggerFactory.getLogger(OracleCloudLoggingSpec.class)
+        def contextLogger = LoggerFactory.getLogger('io.micronaut.context.env.DefaultEnvironment')
         PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory()
         ListAppender listAppender
+        OracleCloudAppender oracleCloudAppender
         loggerContext.loggerList.each { Logger l ->
             l.iteratorForAppenders().each { appender ->
                 if (appender.name == 'ORACLE') {
-                    OracleCloudAppender oracleCloudAppender = (OracleCloudAppender) appender
+                    oracleCloudAppender = (OracleCloudAppender) appender
                     listAppender = (ListAppender) oracleCloudAppender.getAppender('MOCK')
                 }
             }
         }
+        oracleCloudAppender.@configuredSuccessfully = false
+        oracleCloudAppender.source = null
+        oracleCloudAppender.type = null
+        oracleCloudAppender.subject = null
+        listAppender.list.clear()
 
         when:
         def instance = Mock(EmbeddedServer.class)
@@ -65,6 +65,7 @@ class OracleCloudLoggingSpec extends Specification {
         def mockLogging = (MockLogging) logging
         1 * instance.getHost() >> testHost
         eventPublisher.publishEvent(event)
+        contextLogger.info('Established active environments: [oraclecloud]')
         logger.info(logMessage)
 
         then:
@@ -84,7 +85,8 @@ class OracleCloudLoggingSpec extends Specification {
                 }
         )
         logEntryBatch.stream().allMatch(x -> x.source == testHost)
-        logEntryBatch.stream().allMatch(x -> x.type == testHost + '.' + applicationConfiguration.getName().get())
+        String expectedType = "${testHost}.${applicationConfiguration.getName().get()}"
+        logEntryBatch.stream().allMatch(x -> expectedType.equals(x.type))
         logEntryBatch.stream().anyMatch(x -> x.subject == applicationConfiguration.getName().get())
 
         logEntries.stream().anyMatch(x -> x.data.contains('io.micronaut.context'))
@@ -105,76 +107,6 @@ class OracleCloudLoggingSpec extends Specification {
             listAppender.list.size() != 0
         }
         listAppender.list.get(0).message == logMessage
-    }
-
-    @Requires(property = "spec.name", value = "OracleCloudLoggingSpec")
-    @Singleton
-    @Replaces(LoggingClient)
-    static class MockLogging implements Logging {
-
-        final List<PutLogsRequest> putLogsRequestList = Collections.synchronizedList(new ArrayList<>())
-
-        private boolean success = true
-
-        @Override
-        void refreshClient() {
-
-        }
-
-        @Override
-        void setEndpoint(String endpoint) {
-
-        }
-
-        @Override
-        void useRealmSpecificEndpointTemplate(boolean use) {
-
-        }
-
-        boolean getSuccess() {
-            return success
-        }
-
-        void setSuccess(boolean success) {
-            this.success = success
-        }
-
-        @Override
-        String getEndpoint() {
-            return 'mock-logging-endpoint'
-        }
-
-        @Override
-        void setRegion(Region region) {
-
-        }
-
-        @Override
-        void setRegion(String regionId) {
-
-        }
-
-        List<PutLogsRequest> getPutLogsRequestList() {
-            synchronized (putLogsRequestList) {
-                return new ArrayList<PutLogsRequest>(putLogsRequestList)
-            }
-        }
-
-        @Override
-        PutLogsResponse putLogs(PutLogsRequest request) {
-            synchronized (putLogsRequestList) {
-                putLogsRequestList.add(request)
-            }
-            if (success) {
-                return PutLogsResponse.builder().opcRequestId("validId").build()
-            }
-            return PutLogsResponse.builder().opcRequestId(null).__httpStatusCode__(404).build()
-        }
-
-        @Override
-        void close() throws Exception {
-
-        }
     }
 
 }

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingSpec.groovy
@@ -13,9 +13,7 @@ import com.oracle.bmc.loggingingestion.responses.PutLogsResponse
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
-import io.micronaut.context.annotation.Value
 import io.micronaut.context.event.ApplicationEventPublisher
-import io.micronaut.core.io.Readable
 import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.runtime.server.event.ServerStartupEvent
@@ -176,16 +174,6 @@ class OracleCloudLoggingSpec extends Specification {
         @Override
         void close() throws Exception {
 
-        }
-    }
-
-    @Requires(property = "spec.name", value = "OracleCloudLoggingSpec")
-    @Singleton
-    static class ReadableConfiguration {
-        final Readable readable
-
-        ReadableConfiguration(@Value('${app.filepath}') Readable readable) {
-            this.readable = readable
         }
     }
 

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/ReadableConfiguration.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/ReadableConfiguration.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.oraclecloud.logging
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import io.micronaut.core.io.Readable
+import jakarta.inject.Singleton
+
+@Requires(property = "app.filepath")
+@Singleton
+class ReadableConfiguration {
+    final Readable readable
+
+    ReadableConfiguration(@Value('${app.filepath}') Readable readable) {
+        this.readable = readable
+    }
+}

--- a/oraclecloud-logging/src/test/resources/data/addresses.csv
+++ b/oraclecloud-logging/src/test/resources/data/addresses.csv
@@ -1,0 +1,2 @@
+street,city
+1 Test Street,Test City


### PR DESCRIPTION
## Summary

- avoid leaking Micronaut Serde Jackson as an API dependency from Oracle Cloud Logging
- use an isolated JSON mapper for log formatting
- allow the appender to pick up the log ID from application configuration when it is not set in logback
- add regression coverage for `Readable` classpath property injection with OCI logging enabled

## Verification

- `./gradlew :micronaut-oraclecloud-logging:test --tests '*OracleCloudLogging*' -q`

Resolves https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/449
