### PR TITLE
Reject OCI blocking calls on Netty event loops

### DIFF
--- a/oraclecloud-certificates/src/main/java/io/micronaut/oraclecloud/certificates/ssl/OracleCloudCertificateProvider.java
+++ b/oraclecloud-certificates/src/main/java/io/micronaut/oraclecloud/certificates/ssl/OracleCloudCertificateProvider.java
@@ -16,6 +16,7 @@
 package io.micronaut.oraclecloud.certificates.ssl;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
@@ -48,6 +49,7 @@ import java.util.List;
 @EachBean(OracleCloudCertificateProperties.class)
 @BootstrapContextCompatible
 @Singleton
+@Context
 final class OracleCloudCertificateProvider implements CertificateProvider, ApplicationEventListener<CertificateEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(OracleCloudCertificateProvider.class);

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/MicronautHttpRequest.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/MicronautHttpRequest.java
@@ -294,6 +294,10 @@ final class MicronautHttpRequest implements HttpRequest {
 
     @Override
     public CompletionStage<HttpResponse> execute() {
+        if (NettyHttpClient.isBlockingOperationOnEventLoop(offloadExecutor)) {
+            return CompletableFuture.failedFuture(NettyHttpClient.blockingOperationOnEventLoopException());
+        }
+
         for (RequestInterceptor interceptor : client.requestInterceptors) {
             interceptor.intercept(this);
         }

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
@@ -79,8 +79,7 @@ final class NettyHttpClient implements HttpClient {
     private static final String BLOCKING_EVENT_LOOP_MESSAGE = "You are trying to run a BlockingHttpClient operation on a netty event "
         + "loop thread. This is a common cause for bugs: Event loops should never be blocked. "
         + "You can either mark your controller as @ExecuteOn(TaskExecutors.BLOCKING), or use the reactive HTTP client "
-        + "to resolve this bug. There is also a configuration option to disable this check if you are certain a "
-        + "blocking operation is fine here.";
+        + "to resolve this bug.";
 
     final boolean legacyNettyClient;
     final boolean hasContext;
@@ -170,7 +169,10 @@ final class NettyHttpClient implements HttpClient {
     }
 
     static boolean isBlockingOperationOnEventLoop(Executor offloadExecutor) {
-        return offloadExecutor != null && Thread.currentThread() instanceof FastThreadLocalThread;
+        Thread thread = Thread.currentThread();
+        return offloadExecutor != null
+            && thread instanceof FastThreadLocalThread fastThreadLocalThread
+            && !fastThreadLocalThread.permitBlockingCalls();
     }
 
     static HttpClientException blockingOperationOnEventLoopException() {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
@@ -28,6 +28,7 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.http.client.DefaultHttpClientConfiguration;
 import io.micronaut.http.client.HttpVersionSelection;
 import io.micronaut.http.client.RawHttpClient;
+import io.micronaut.http.client.exceptions.HttpClientException;
 import io.micronaut.http.client.exceptions.ResponseClosedException;
 import io.micronaut.http.client.netty.ConnectionManager;
 import io.micronaut.http.client.netty.DefaultHttpClient;
@@ -36,6 +37,7 @@ import io.micronaut.oraclecloud.serde.OciSdkMicronautSerializer;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.PrematureChannelClosureException;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +57,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
@@ -73,6 +76,11 @@ final class NettyHttpClient implements HttpClient {
     private static final boolean LEGACY_NETTY_CLIENT = Boolean.getBoolean("io.micronaut.oraclecloud.httpclient.netty.legacy-netty-client");
 
     private static final Logger LOG = LoggerFactory.getLogger(NettyHttpClient.class);
+    private static final String BLOCKING_EVENT_LOOP_MESSAGE = "You are trying to run a BlockingHttpClient operation on a netty event "
+        + "loop thread. This is a common cause for bugs: Event loops should never be blocked. "
+        + "You can either mark your controller as @ExecuteOn(TaskExecutors.BLOCKING), or use the reactive HTTP client "
+        + "to resolve this bug. There is also a configuration option to disable this check if you are certain a "
+        + "blocking operation is fine here.";
 
     final boolean legacyNettyClient;
     final boolean hasContext;
@@ -159,6 +167,14 @@ final class NettyHttpClient implements HttpClient {
 
     ByteBufAllocator alloc() {
         return connectionManager == null ? ByteBufAllocator.DEFAULT : connectionManager.alloc();
+    }
+
+    static boolean isBlockingOperationOnEventLoop(Executor offloadExecutor) {
+        return offloadExecutor != null && Thread.currentThread() instanceof FastThreadLocalThread;
+    }
+
+    static HttpClientException blockingOperationOnEventLoopException() {
+        return new HttpClientException(BLOCKING_EVENT_LOOP_MESSAGE);
     }
 
     String baseUri() {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpRequest.java
@@ -268,6 +268,10 @@ final class NettyHttpRequest implements HttpRequest {
 
     @Override
     public CompletionStage<HttpResponse> execute() {
+        if (NettyHttpClient.isBlockingOperationOnEventLoop(offloadExecutor)) {
+            return CompletableFuture.failedFuture(NettyHttpClient.blockingOperationOnEventLoopException());
+        }
+
         // jersey client buffers even when BUFFER_REQUEST is off, if the content length is not explicitly set.
         if (blockingBody != null && (client.buffered || blockingContentLength == UNKNOWN_CONTENT_LENGTH) && !expectContinue) {
 

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/ManagedBlockingTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/ManagedBlockingTest.java
@@ -15,6 +15,7 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientException;
 import io.micronaut.runtime.server.EmbeddedServer;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
 public class ManagedBlockingTest {
@@ -49,15 +52,64 @@ public class ManagedBlockingTest {
 
     @Test
     public void testBlockingFromUnrelatedEventLoop() throws Exception {
+        assertBlockingFromUnrelatedEventLoop(false);
+    }
+
+    @Test
+    public void testBlockingFromUnrelatedEventLoopWithLegacyClient() throws Exception {
+        assertBlockingFromUnrelatedEventLoop(true);
+    }
+
+    @Test
+    public void testPermittedFastThreadLocalThreadIsNotRejected() throws Exception {
+        Executor offloadExecutor = Runnable::run;
+        FutureTask<Boolean> task = new FutureTask<>(() -> NettyHttpClient.isBlockingOperationOnEventLoop(offloadExecutor));
+        FastThreadLocalThread thread = new FastThreadLocalThread(task, "permitted-fast-thread-local") {
+            @Override
+            public boolean permitBlockingCalls() {
+                return true;
+            }
+        };
+
+        thread.start();
+
+        Assertions.assertFalse(task.get(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testBlockingFromRegularThreadSucceeds() throws Exception {
         try (ApplicationContext ctx = ApplicationContext.run(Map.of(
             "spec.name", "ManagedBlockingTest",
             "micronaut.server.port", 0
         )); EmbeddedServer server = ctx.getBean(EmbeddedServer.class)) {
             server.start();
-            NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1);
             try (com.oracle.bmc.http.client.HttpClient cl = new NettyHttpProvider().newBuilder()
                 .baseUri(server.getURI())
                 .build()) {
+                FakeResponse response = ClientCall.builder(cl, new FakeRequest(), FakeResponse.Builder::new)
+                    .logger(LOG, "ManagedBlockingTest")
+                    .method(Method.GET)
+                    .appendPathPart("/managed-blocking/simple")
+                    .callSync();
+
+                Assertions.assertEquals(200, response.get__httpStatusCode__());
+            }
+        }
+    }
+
+    private static void assertBlockingFromUnrelatedEventLoop(boolean legacyNettyClient) throws Exception {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "spec.name", "ManagedBlockingTest",
+            "micronaut.server.port", 0,
+            "oci.netty.legacy-netty-client", legacyNettyClient
+        )); EmbeddedServer server = ctx.getBean(EmbeddedServer.class)) {
+            server.start();
+            NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1);
+            HttpProvider httpProvider = legacyNettyClient ? ctx.getBean(HttpProvider.class) : new NettyHttpProvider();
+            try (com.oracle.bmc.http.client.HttpClient cl = httpProvider.newBuilder()
+                .baseUri(server.getURI())
+                .build()) {
+                Assertions.assertEquals(legacyNettyClient, ((NettyHttpClient) cl).legacyNettyClient);
                 BmcException exception = eventLoopGroup.next().submit(() -> {
                     try {
                         ClientCall.builder(cl, new FakeRequest(), FakeResponse.Builder::new)

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/ManagedBlockingTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/ManagedBlockingTest.java
@@ -14,6 +14,7 @@ import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientException;
 import io.micronaut.runtime.server.EmbeddedServer;
+import io.netty.channel.nio.NioEventLoopGroup;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class ManagedBlockingTest {
     private static final Logger LOG = LoggerFactory.getLogger(ManagedBlockingTest.class);
@@ -41,8 +43,41 @@ public class ManagedBlockingTest {
             BmcException exception = ctx.getBean(MyCtrl.class).exc;
             Throwable cause = exception.getCause();
             Assertions.assertInstanceOf(HttpClientException.class, cause);
-            // Client 'oci': Connect Error: Failed to perform blocking request on the event loop because request execution would be dispatched on the same event loop. This would lead to a deadlock. Either configure the HTTP client to use a different event loop, or use the reactive HTTP client. https://docs.micronaut.io/latest/guide/index.html#clientConfiguration
-            Assertions.assertTrue(cause.getMessage().contains("blocking request"));
+            Assertions.assertTrue(cause.getMessage().contains("BlockingHttpClient operation on a netty event loop"));
+        }
+    }
+
+    @Test
+    public void testBlockingFromUnrelatedEventLoop() throws Exception {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "spec.name", "ManagedBlockingTest",
+            "micronaut.server.port", 0
+        )); EmbeddedServer server = ctx.getBean(EmbeddedServer.class)) {
+            server.start();
+            NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1);
+            try (com.oracle.bmc.http.client.HttpClient cl = new NettyHttpProvider().newBuilder()
+                .baseUri(server.getURI())
+                .build()) {
+                BmcException exception = eventLoopGroup.next().submit(() -> {
+                    try {
+                        ClientCall.builder(cl, new FakeRequest(), FakeResponse.Builder::new)
+                            .logger(LOG, "ManagedBlockingTest")
+                            .method(Method.GET)
+                            .appendPathPart("/managed-blocking/simple")
+                            .callSync();
+                    } catch (BmcException e) {
+                        return e;
+                    }
+                    return null;
+                }).get(10, TimeUnit.SECONDS);
+
+                Assertions.assertNotNull(exception);
+                Throwable cause = exception.getCause();
+                Assertions.assertInstanceOf(HttpClientException.class, cause);
+                Assertions.assertTrue(cause.getMessage().contains("BlockingHttpClient operation on a netty event loop"));
+            } finally {
+                eventLoopGroup.shutdownGracefully().sync();
+            }
         }
     }
 

--- a/src/main/docs/guide/httpclient.adoc
+++ b/src/main/docs/guide/httpclient.adoc
@@ -87,6 +87,11 @@ You can find a client’s service ID by checking the factory class that creates 
 
 NOTE: Choose either `micronaut.http.services.oci` or `oci.client` to configure your OCI client; supplying both will cause a `NonUniqueBeanException`.
 
+#### Blocking calls
+
+Synchronous OCI SDK calls that use this Netty client must not be executed on a Netty event-loop thread.
+If a blocking call is needed from a controller or other request-handling code, move it to a blocking executor, for example with `@ExecuteOn(TaskExecutors.BLOCKING)`, or use a reactive client API.
+
 #### Logging
 
 To enable logging of all requests, set the `micronaut.http.services.oci.log-level` or `oci.client.log-level` property to `INFO`.


### PR DESCRIPTION
## Summary
- fail OCI SDK blocking requests immediately when they are executed from a Netty event loop
- apply the guard to both Micronaut-backed and Netty-backed OCI HTTP requests
- add managed blocking coverage for an unrelated Netty event loop

## Verification
- `git diff --check`
- `./gradlew :micronaut-oraclecloud-httpclient-netty:test --tests io.micronaut.oraclecloud.httpclient.netty.ManagedBlockingTest` failed before reaching tests because Gradle reported `Gradle build daemon has been stopped: stop command received` after compiling dependent modules.

Resolves https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/1250
