### PR TITLE
Make OCI Netty client use daemon threads

### DIFF
--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClient.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -73,6 +74,8 @@ final class NettyHttpClient implements HttpClient {
     private static final boolean LEGACY_NETTY_CLIENT = Boolean.getBoolean("io.micronaut.oraclecloud.httpclient.netty.legacy-netty-client");
 
     private static final Logger LOG = LoggerFactory.getLogger(NettyHttpClient.class);
+
+    private static final ThreadFactory DAEMON_BLOCKING_IO_THREAD_FACTORY = new OciNettyDaemonThreadFactory("oci-netty-blocking");
 
     final boolean legacyNettyClient;
     final boolean hasContext;
@@ -102,18 +105,9 @@ final class NettyHttpClient implements HttpClient {
         if (builder.managedProvider == null) {
             hasContext = false;
             ownsThreadPool = true;
-            DefaultHttpClientConfiguration cfg = new DefaultHttpClientConfiguration();
-            // Configure proxy via system properties for OCI use-cases
-            applyProxyFromSystemProperties(cfg, LOG);
-
-            if (builder.properties.containsKey(StandardClientProperties.CONNECT_TIMEOUT)) {
-                cfg.setConnectTimeout((Duration) builder.properties.get(StandardClientProperties.CONNECT_TIMEOUT));
-            }
-            if (builder.properties.containsKey(StandardClientProperties.READ_TIMEOUT)) {
-                cfg.setReadTimeout((Duration) builder.properties.get(StandardClientProperties.READ_TIMEOUT));
-            }
+            DefaultHttpClientConfiguration cfg = unmanagedClientConfiguration(builder.properties);
             mnClient = RawHttpClient.create(null, cfg);
-            blockingIoExecutor = Executors.newCachedThreadPool();
+            blockingIoExecutor = Executors.newCachedThreadPool(DAEMON_BLOCKING_IO_THREAD_FACTORY);
             jsonMapper = OciSdkMicronautSerializer.getDefaultObjectMapper();
         } else {
             hasContext = true;
@@ -155,6 +149,21 @@ final class NettyHttpClient implements HttpClient {
         }
 
         this.buffered = builder.buffered;
+    }
+
+    static DefaultHttpClientConfiguration unmanagedClientConfiguration(Map<ClientProperty<?>, Object> properties) {
+        DefaultHttpClientConfiguration cfg = new DefaultHttpClientConfiguration();
+        cfg.setThreadFactory(OciNettyDaemonThreadFactory.class);
+        // Configure proxy via system properties for OCI use-cases
+        applyProxyFromSystemProperties(cfg, LOG);
+
+        if (properties.containsKey(StandardClientProperties.CONNECT_TIMEOUT)) {
+            cfg.setConnectTimeout((Duration) properties.get(StandardClientProperties.CONNECT_TIMEOUT));
+        }
+        if (properties.containsKey(StandardClientProperties.READ_TIMEOUT)) {
+            cfg.setReadTimeout((Duration) properties.get(StandardClientProperties.READ_TIMEOUT));
+        }
+        return cfg;
     }
 
     ByteBufAllocator alloc() {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/OciNettyDaemonThreadFactory.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/OciNettyDaemonThreadFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.httpclient.netty;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Daemon thread factory for unmanaged OCI Netty HTTP client resources.
+ */
+@Internal
+public final class OciNettyDaemonThreadFactory implements ThreadFactory {
+    private final AtomicInteger counter = new AtomicInteger();
+    private final String namePrefix;
+
+    public OciNettyDaemonThreadFactory() {
+        this("oci-netty-http-client");
+    }
+
+    OciNettyDaemonThreadFactory(String namePrefix) {
+        this.namePrefix = namePrefix;
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        Thread thread = new Thread(runnable, namePrefix + '-' + counter.incrementAndGet());
+        thread.setDaemon(true);
+        return thread;
+    }
+}

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClientTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/NettyHttpClientTest.java
@@ -21,11 +21,31 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 class NettyHttpClientTest {
+    @Test
+    public void unmanagedClientUsesDaemonThreads() throws Exception {
+        Assertions.assertEquals(
+            OciNettyDaemonThreadFactory.class,
+            NettyHttpClient.unmanagedClientConfiguration(Collections.emptyMap()).getThreadFactory().orElseThrow()
+        );
+        Assertions.assertTrue(new OciNettyDaemonThreadFactory().newThread(() -> {
+        }).isDaemon());
+
+        NettyHttpClient client = (NettyHttpClient) new NettyHttpClientBuilder(null)
+            .baseUri("http://localhost")
+            .build();
+        try {
+            Assertions.assertTrue(client.blockingIoExecutor.submit(() -> Thread.currentThread().isDaemon()).get());
+        } finally {
+            client.close();
+        }
+    }
+
     @Test
     public void simple() throws Exception {
         Map<String, Object> properties = new java.util.HashMap<>();


### PR DESCRIPTION
## Summary

- use daemon threads for unmanaged OCI Netty HTTP client resources
- configure the unmanaged raw Micronaut client with a daemon thread factory
- cover the unmanaged client configuration and blocking IO executor daemon behavior

## Tests

- `./gradlew :micronaut-oraclecloud-httpclient-netty:test --tests io.micronaut.oraclecloud.httpclient.netty.NettyHttpClientTest -q` (passed before rebasing onto the updated `origin/6.0.x`)
- reran after rebase, but Gradle stopped during compilation with `Gradle build daemon has been stopped: stop command received` before tests completed

Resolves https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/676
