### PR TITLE
Extract OCI serde configuration beans

### DIFF
--- a/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/DefaultOciSerdeConfiguration.java
+++ b/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/DefaultOciSerdeConfiguration.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.httpclient.apache.core.serde;
+
+import com.oracle.bmc.auth.internal.GetResourcePrincipalSessionTokenRequest;
+import com.oracle.bmc.auth.internal.JWK;
+import com.oracle.bmc.auth.internal.X509FederationClient;
+import com.oracle.bmc.auth.okeworkloadidentity.internal.GetOkeResourcePrincipalSessionTokenDetails;
+import com.oracle.bmc.auth.okeworkloadidentity.internal.OkeResourcePrincipalSessionToken;
+import com.oracle.bmc.encryption.internal.EncryptionHeader;
+import com.oracle.bmc.encryption.internal.EncryptionKey;
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.model.RegionSchema;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.annotation.SerdeImport;
+import io.micronaut.serde.config.SerdeConfiguration;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * Default OCI-specific serde configuration.
+ */
+@ConfigurationProperties("oci.serde")
+@Bean(typed = OciSerdeConfiguration.class)
+@Internal
+@BootstrapContextCompatible
+@SerdeImport(GetResourcePrincipalSessionTokenRequest.class)
+@SerdeImport(JWK.class)
+@SerdeImport(RegionSchema.class)
+@SerdeImport(ResponseHelper.ErrorCodeAndMessage.class)
+@SerdeImport(X509FederationClient.SecurityToken.class)
+@SerdeImport(X509FederationClient.X509FederationRequest.class)
+@SerdeImport(GetOkeResourcePrincipalSessionTokenDetails.class)
+@SerdeImport(OkeResourcePrincipalSessionToken.class)
+@SerdeImport(value = EncryptionHeader.class, deserializable = false)
+@SerdeImport(EncryptionKey.class)
+final class DefaultOciSerdeConfiguration implements OciSerdeConfiguration {
+    private Optional<String> dateFormat = Optional.empty();
+    private SerdeConfiguration.TimeShape timeWriteShape = SerdeConfiguration.TimeShape.STRING;
+    private SerdeConfiguration.NumericTimeUnit numericTimeUnit = SerdeConfiguration.NumericTimeUnit.SECONDS;
+    private boolean writeBinaryAsArray;
+    private Optional<Locale> locale = Optional.empty();
+    private Optional<TimeZone> timeZone = Optional.empty();
+    private List<String> includedIntrospectionPackages = List.of("io.micronaut");
+    private int maximumNestingDepth = LimitingStream.DEFAULT_MAXIMUM_DEPTH;
+
+    @Override
+    public Optional<String> getDateFormat() {
+        return dateFormat;
+    }
+
+    public void setDateFormat(Optional<String> dateFormat) {
+        this.dateFormat = dateFormat == null ? Optional.empty() : dateFormat;
+    }
+
+    @Override
+    @Bindable(defaultValue = "STRING")
+    public SerdeConfiguration.TimeShape getTimeWriteShape() {
+        return timeWriteShape;
+    }
+
+    public void setTimeWriteShape(SerdeConfiguration.TimeShape timeWriteShape) {
+        this.timeWriteShape = timeWriteShape;
+    }
+
+    @Override
+    @Bindable(defaultValue = "SECONDS")
+    public SerdeConfiguration.NumericTimeUnit getNumericTimeUnit() {
+        return numericTimeUnit;
+    }
+
+    public void setNumericTimeUnit(SerdeConfiguration.NumericTimeUnit numericTimeUnit) {
+        this.numericTimeUnit = numericTimeUnit;
+    }
+
+    @Override
+    @Bindable(defaultValue = "false")
+    public boolean isWriteBinaryAsArray() {
+        return writeBinaryAsArray;
+    }
+
+    public void setWriteBinaryAsArray(boolean writeBinaryAsArray) {
+        this.writeBinaryAsArray = writeBinaryAsArray;
+    }
+
+    @Override
+    public Optional<Locale> getLocale() {
+        return locale;
+    }
+
+    public void setLocale(Optional<Locale> locale) {
+        this.locale = locale == null ? Optional.empty() : locale;
+    }
+
+    @Override
+    public Optional<TimeZone> getTimeZone() {
+        return timeZone;
+    }
+
+    public void setTimeZone(Optional<TimeZone> timeZone) {
+        this.timeZone = timeZone == null ? Optional.empty() : timeZone;
+    }
+
+    @Override
+    @Bindable(defaultValue = "io.micronaut")
+    public List<String> getIncludedIntrospectionPackages() {
+        return includedIntrospectionPackages;
+    }
+
+    public void setIncludedIntrospectionPackages(List<String> includedIntrospectionPackages) {
+        this.includedIntrospectionPackages = includedIntrospectionPackages;
+    }
+
+    @Override
+    @Bindable(defaultValue = LimitingStream.DEFAULT_MAXIMUM_DEPTH + "")
+    public int getMaximumNestingDepth() {
+        return maximumNestingDepth;
+    }
+
+    public void setMaximumNestingDepth(int maximumNestingDepth) {
+        this.maximumNestingDepth = maximumNestingDepth;
+    }
+}

--- a/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/DefaultOciSerializationConfiguration.java
+++ b/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/DefaultOciSerializationConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.httpclient.apache.core.serde;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+/**
+ * Default OCI-specific serialization configuration.
+ */
+@ConfigurationProperties("oci.serde.serialization")
+@Bean(typed = OciSerializationConfiguration.class)
+@Internal
+@BootstrapContextCompatible
+final class DefaultOciSerializationConfiguration implements OciSerializationConfiguration {
+    private SerdeConfig.SerInclude inclusion = SerdeConfig.SerInclude.NON_NULL;
+    private boolean alwaysSerializeErrorsAsList = true;
+
+    @Override
+    @Bindable(defaultValue = "NON_NULL")
+    public SerdeConfig.SerInclude getInclusion() {
+        return inclusion;
+    }
+
+    public void setInclusion(SerdeConfig.SerInclude inclusion) {
+        this.inclusion = inclusion;
+    }
+
+    @Override
+    @Bindable(defaultValue = "true")
+    public boolean isAlwaysSerializeErrorsAsList() {
+        return alwaysSerializeErrorsAsList;
+    }
+
+    public void setAlwaysSerializeErrorsAsList(boolean alwaysSerializeErrorsAsList) {
+        this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
+    }
+}

--- a/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/OciSerdeConfiguration.java
+++ b/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/OciSerdeConfiguration.java
@@ -15,40 +15,14 @@
  */
 package io.micronaut.oraclecloud.httpclient.apache.core.serde;
 
-import com.oracle.bmc.auth.internal.GetResourcePrincipalSessionTokenRequest;
-import com.oracle.bmc.auth.internal.JWK;
-import com.oracle.bmc.auth.internal.X509FederationClient;
-import com.oracle.bmc.auth.okeworkloadidentity.internal.GetOkeResourcePrincipalSessionTokenDetails;
-import com.oracle.bmc.auth.okeworkloadidentity.internal.OkeResourcePrincipalSessionToken;
-import com.oracle.bmc.encryption.internal.EncryptionHeader;
-import com.oracle.bmc.encryption.internal.EncryptionKey;
-import com.oracle.bmc.http.internal.ResponseHelper;
-import com.oracle.bmc.model.RegionSchema;
-import io.micronaut.context.annotation.Bean;
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
-import io.micronaut.serde.annotation.SerdeImport;
 import io.micronaut.serde.config.SerdeConfiguration;
 
 /**
  * OCI-specific serde configuration.
  */
-@ConfigurationProperties("oci.serde")
-@Bean(typed = OciSerdeConfiguration.class)
 @Internal
-@BootstrapContextCompatible
-@SerdeImport(GetResourcePrincipalSessionTokenRequest.class)
-@SerdeImport(JWK.class)
-@SerdeImport(RegionSchema.class)
-@SerdeImport(ResponseHelper.ErrorCodeAndMessage.class)
-@SerdeImport(X509FederationClient.SecurityToken.class)
-@SerdeImport(X509FederationClient.X509FederationRequest.class)
-@SerdeImport(GetOkeResourcePrincipalSessionTokenDetails.class)
-@SerdeImport(OkeResourcePrincipalSessionToken.class)
-@SerdeImport(value = EncryptionHeader.class, deserializable = false)
-@SerdeImport(EncryptionKey.class)
 public interface OciSerdeConfiguration extends SerdeConfiguration {
     @Override
     @Bindable(defaultValue = "false")

--- a/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/OciSerializationConfiguration.java
+++ b/oraclecloud-httpclient-apache-http-core/src/main/java/io/micronaut/oraclecloud/httpclient/apache/core/serde/OciSerializationConfiguration.java
@@ -15,9 +15,6 @@
  */
 package io.micronaut.oraclecloud.httpclient.apache.core.serde;
 
-import io.micronaut.context.annotation.Bean;
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.serde.config.SerializationConfiguration;
@@ -26,10 +23,7 @@ import io.micronaut.serde.config.annotation.SerdeConfig;
 /**
  * OCI-specific serialization configuration.
  */
-@ConfigurationProperties("oci.serde.serialization")
-@Bean(typed = OciSerializationConfiguration.class)
 @Internal
-@BootstrapContextCompatible
 public interface OciSerializationConfiguration extends SerializationConfiguration {
     @Bindable(defaultValue = "NON_NULL")
     @Override

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/DefaultOciSerdeConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/DefaultOciSerdeConfiguration.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serde;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.config.SerdeConfiguration;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/**
+ * Default OCI-specific serde configuration.
+ */
+@ConfigurationProperties("oci.serde")
+@Bean(typed = OciSerdeConfiguration.class)
+@Internal
+@BootstrapContextCompatible
+final class DefaultOciSerdeConfiguration implements OciSerdeConfiguration {
+    private Optional<String> dateFormat = Optional.empty();
+    private SerdeConfiguration.TimeShape timeWriteShape = SerdeConfiguration.TimeShape.STRING;
+    private SerdeConfiguration.NumericTimeUnit numericTimeUnit = SerdeConfiguration.NumericTimeUnit.SECONDS;
+    private boolean writeBinaryAsArray;
+    private Optional<Locale> locale = Optional.empty();
+    private Optional<TimeZone> timeZone = Optional.empty();
+    private List<String> includedIntrospectionPackages = List.of("io.micronaut");
+    private int maximumNestingDepth = LimitingStream.DEFAULT_MAXIMUM_DEPTH;
+
+    @Override
+    public Optional<String> getDateFormat() {
+        return dateFormat;
+    }
+
+    public void setDateFormat(Optional<String> dateFormat) {
+        this.dateFormat = dateFormat == null ? Optional.empty() : dateFormat;
+    }
+
+    @Override
+    @Bindable(defaultValue = "STRING")
+    public SerdeConfiguration.TimeShape getTimeWriteShape() {
+        return timeWriteShape;
+    }
+
+    public void setTimeWriteShape(SerdeConfiguration.TimeShape timeWriteShape) {
+        this.timeWriteShape = timeWriteShape;
+    }
+
+    @Override
+    @Bindable(defaultValue = "SECONDS")
+    public SerdeConfiguration.NumericTimeUnit getNumericTimeUnit() {
+        return numericTimeUnit;
+    }
+
+    public void setNumericTimeUnit(SerdeConfiguration.NumericTimeUnit numericTimeUnit) {
+        this.numericTimeUnit = numericTimeUnit;
+    }
+
+    @Override
+    @Bindable(defaultValue = "false")
+    public boolean isWriteBinaryAsArray() {
+        return writeBinaryAsArray;
+    }
+
+    public void setWriteBinaryAsArray(boolean writeBinaryAsArray) {
+        this.writeBinaryAsArray = writeBinaryAsArray;
+    }
+
+    @Override
+    public Optional<Locale> getLocale() {
+        return locale;
+    }
+
+    public void setLocale(Optional<Locale> locale) {
+        this.locale = locale == null ? Optional.empty() : locale;
+    }
+
+    @Override
+    public Optional<TimeZone> getTimeZone() {
+        return timeZone;
+    }
+
+    public void setTimeZone(Optional<TimeZone> timeZone) {
+        this.timeZone = timeZone == null ? Optional.empty() : timeZone;
+    }
+
+    @Override
+    @Bindable(defaultValue = "io.micronaut")
+    public List<String> getIncludedIntrospectionPackages() {
+        return includedIntrospectionPackages;
+    }
+
+    public void setIncludedIntrospectionPackages(List<String> includedIntrospectionPackages) {
+        this.includedIntrospectionPackages = includedIntrospectionPackages;
+    }
+
+    @Override
+    @Bindable(defaultValue = LimitingStream.DEFAULT_MAXIMUM_DEPTH + "")
+    public int getMaximumNestingDepth() {
+        return maximumNestingDepth;
+    }
+
+    public void setMaximumNestingDepth(int maximumNestingDepth) {
+        this.maximumNestingDepth = maximumNestingDepth;
+    }
+}

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/DefaultOciSerializationConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/DefaultOciSerializationConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serde;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+/**
+ * Default OCI-specific serialization configuration.
+ */
+@ConfigurationProperties("oci.serde.serialization")
+@Bean(typed = OciSerializationConfiguration.class)
+@Internal
+@BootstrapContextCompatible
+final class DefaultOciSerializationConfiguration implements OciSerializationConfiguration {
+    private SerdeConfig.SerInclude inclusion = SerdeConfig.SerInclude.NON_NULL;
+    private boolean alwaysSerializeErrorsAsList = true;
+
+    @Override
+    @Bindable(defaultValue = "NON_NULL")
+    public SerdeConfig.SerInclude getInclusion() {
+        return inclusion;
+    }
+
+    public void setInclusion(SerdeConfig.SerInclude inclusion) {
+        this.inclusion = inclusion;
+    }
+
+    @Override
+    @Bindable(defaultValue = "true")
+    public boolean isAlwaysSerializeErrorsAsList() {
+        return alwaysSerializeErrorsAsList;
+    }
+
+    public void setAlwaysSerializeErrorsAsList(boolean alwaysSerializeErrorsAsList) {
+        this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
+    }
+}

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerdeConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerdeConfiguration.java
@@ -15,17 +15,14 @@
  */
 package io.micronaut.oraclecloud.serde;
 
-import io.micronaut.context.annotation.Bean;
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.serde.config.SerdeConfiguration;
 
-@ConfigurationProperties("oci.serde")
-@Bean(typed = OciSerdeConfiguration.class)
+/**
+ * OCI-specific serde configuration.
+ */
 @Internal
-@BootstrapContextCompatible
 public interface OciSerdeConfiguration extends SerdeConfiguration {
     @Override
     @Bindable(defaultValue = "false")

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerializationConfiguration.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSerializationConfiguration.java
@@ -15,18 +15,15 @@
  */
 package io.micronaut.oraclecloud.serde;
 
-import io.micronaut.context.annotation.Bean;
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 
-@ConfigurationProperties("oci.serde.serialization")
-@Bean(typed = OciSerializationConfiguration.class)
+/**
+ * OCI-specific serialization configuration.
+ */
 @Internal
-@BootstrapContextCompatible
 public interface OciSerializationConfiguration extends SerializationConfiguration {
     @Bindable(defaultValue = "NON_NULL")
     @Override

--- a/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
+++ b/oraclecloud-logging/src/test/groovy/io/micronaut/oraclecloud/logging/OracleCloudLoggingAppenderSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.oraclecloud.logging
 
 import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.PatternLayout
 import ch.qos.logback.classic.spi.LoggingEvent
@@ -9,17 +10,37 @@ import ch.qos.logback.core.read.ListAppender
 import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.runtime.server.event.ServerStartupEvent
+import org.slf4j.LoggerFactory
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 
 class OracleCloudLoggingAppenderSpec extends Specification {
 
+    @Shared
+    OracleCloudAppender logbackOracleAppender
+
+    @Shared
+    boolean logbackOracleAppenderStarted
+
     OracleCloudAppender appender
     LoggerContext context
     PatternLayout layout
     LayoutWrappingEncoder encoder
     OracleCloudLoggingSpec.MockLogging oracleCloudLogsClient
+
+    def setupSpec() {
+        logbackOracleAppender = findLogbackOracleAppender()
+        logbackOracleAppenderStarted = logbackOracleAppender?.started ?: false
+        logbackOracleAppender?.stop()
+    }
+
+    def cleanupSpec() {
+        if (logbackOracleAppenderStarted) {
+            logbackOracleAppender.start()
+        }
+    }
 
     def setup() {
         context = new LoggerContext()
@@ -228,5 +249,19 @@ class OracleCloudLoggingAppenderSpec extends Specification {
             event.timeStamp = time
         }
         return event
+    }
+
+    private static OracleCloudAppender findLogbackOracleAppender() {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory()
+        for (Logger logger : loggerContext.loggerList) {
+            def iterator = logger.iteratorForAppenders()
+            while (iterator.hasNext()) {
+                def appender = iterator.next()
+                if (appender.name == 'ORACLE' && appender instanceof OracleCloudAppender) {
+                    return (OracleCloudAppender) appender
+                }
+            }
+        }
+        return null
     }
 }


### PR DESCRIPTION
This pull-request workarounds a compilation issue after updating to serde 3.0.0-RC2

> SerdeConfiguration in serde 3.0.0-RC2 now has a static helper named serializationFeatures(...). The configuration processor is still seeing it while validating the interface. @AccessorsStyle could not solve this because the processor was seeing SerdeConfiguration.serializationFeatures(...), which has an argument and is not a getter.

Workaround:

>  I kept the existing OciSerdeConfiguration / OciSerializationConfiguration interfaces as the internal injection contracts, and moved @ConfigurationProperties, @Bean, bootstrap compatibility, defaults, and Apache @SerdeImports onto package-local default implementations.
> Keep  OciSerdeConfiguration as the injection/API contract and move the actual @ConfigurationProperties bean onto a package-local implementation. That avoids the interface validator path while preserving constructor injection sites that depend on OciSerdeConfiguration.

I also had to isolate the Oracle Cloud logging appender test
>   The test now stops the shared Logback ORACLE appender during OracleCloudLoggingAppenderSpec and restarts it afterward if it was originally running. That prevents the unit spec from configuring the global appender with its temporary OracleCloudLoggingClient state.