### PR TITLE
Fix release provenance subject handoff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ on:
     types: [published]
 jobs:
   release:
-    outputs:
-      artifacts-sha256: ${{ steps.hash.outputs.artifacts-sha256 }} # Computed hashes for build artifacts.
     runs-on: ubuntu-latest
     steps:
       - name: Remove system JDKs
@@ -91,8 +89,6 @@ jobs:
           # Compute the hashes for the publication artifacts.
           HASHES=$(sha256sum -- "${ARTIFACTS[@]}" | base64 -w0)
           cd ../..
-          # Set the hash as job output for debugging.
-          echo "artifacts-sha256=$HASHES" >> "$GITHUB_OUTPUT"
           # Store the hash in a file, which is uploaded as a workflow artifact.
           echo -n "$HASHES" > artifacts-sha256
       - name: Upload build artifacts
@@ -145,21 +141,20 @@ jobs:
     needs: [release]
     runs-on: ubuntu-latest
     outputs:
-      artifacts-sha256: ${{ steps.set-hash.outputs.artifacts-sha256 }}
+      base64-subjects-as-file: ${{ steps.subjects.outputs.handle }}
     steps:
       - name: Download artifacts-sha256
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: artifacts-sha256
-      # The SLSA provenance generator expects the hash digest of artifacts to be passed as a job
-      # output. So we need to download the artifacts-sha256 and set it as job output. The hash of
-      # the artifacts should be set as output directly in the release job. But due to a known bug
-      # in GitHub Actions we have to use a workaround.
-      # See https://github.com/community/community/discussions/37942.
-      - name: Set artifacts-sha256 as output
-        id: set-hash
-        shell: bash
-        run: echo "artifacts-sha256=$(cat artifacts-sha256)" >> "$GITHUB_OUTPUT"
+      # The SLSA provenance generator supports large subject lists via a file handle.
+      # The helper expects this already-base64 subject file and returns a small handle
+      # containing artifact metadata, avoiding GitHub Actions job output size limits.
+      - name: Create SLSA subjects file handle
+        id: subjects
+        uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+        with:
+          path: artifacts-sha256
 
   provenance:
     needs: [release, provenance-subject]
@@ -169,7 +164,7 @@ jobs:
       contents: write # To add assets to a release.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
-      base64-subjects: "${{ needs.provenance-subject.outputs.artifacts-sha256 }}"
+      base64-subjects-as-file: "${{ needs.provenance-subject.outputs.base64-subjects-as-file }}"
       upload-assets: true # Upload to a new release.
       compile-generator: true # Build the generator from source.
 


### PR DESCRIPTION
## Summary

- stop passing the full release artifact SHA-256 subject list through GitHub Actions job outputs
- keep the `artifacts-sha256` subject file artifact and hand it to SLSA via `base64-subjects-as-file`
- use the SLSA generator helper to create a small verified file handle for large subject lists

## Context

This copies the workflow change from micronaut-projects/micronaut-project-template#720 into Micronaut Oracle Cloud so it can be tested here before being propagated to other projects.

The failed 6.0.0 release generated a 2.6 MB base64 `artifacts-sha256` subject list for 10,320 published files. Writing that value to `$GITHUB_OUTPUT` caused GitHub Actions to fail at job completion with `Maximum object size exceeded` while evaluating job outputs.

This preserves release accountability: the same subject hashes are still generated and consumed by SLSA, but the payload is transported through SLSA's supported file-handle mechanism instead of a giant job output string.

## Verification

- parsed `.github/workflows/release.yml` with PyYAML
- asserted the release job no longer exposes `steps.hash.outputs.artifacts-sha256`
- asserted the provenance job uses `base64-subjects-as-file`
- simulated the real 2.6 MB subject payload producing a small SLSA handle
- `git diff --check`

Resolves #1303
