### PR TITLE
Add Jackson Databind dependency constraints

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.ocisdk-metadata-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.ocisdk-metadata-module.gradle
@@ -6,6 +6,11 @@ plugins {
 }
 
 dependencies {
+    constraints {
+        implementation(libs.jackson2.databind)
+        runtimeOnly(libs.jackson2.databind)
+    }
+
     annotationProcessor(projects.micronautOraclecloudSerdeInternalProcessor)
     // The dependency is required for annotations and their metadata
     implementation(mnSerde.micronaut.serde.api)

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-base.gradle
@@ -7,6 +7,13 @@ repositories {
 }
 
 dependencies {
+    constraints {
+        implementation(libs.jackson2.databind)
+        compileOnly(libs.jackson2.databind)
+        testImplementation(libs.jackson2.databind)
+        testRuntimeOnly(libs.jackson2.databind)
+    }
+
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mnTest.junit.platform.launcher)
     testImplementation(mnTest.micronaut.test.junit5)

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-native-tests.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.oraclecloud-native-tests.gradle
@@ -14,6 +14,7 @@ graalvmNative {
     toolchainDetection = false
     metadataRepository {
         enabled = true
+        excludedModules.add("com.fasterxml.jackson.core:jackson-databind")
     }
     binaries {
         configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ oci = "3.86.1"
 protobuf = '0.9.6'
 shadow = '9.4.1'
 slf4j-jcl = '2.0.17'
-jackson2 = "2.21.4"
+jackson2 = "2.21.5"
 
 managed-apache-http-core5 = "5.4.2"
 micronaut-discovery-client = "5.0.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/oraclecloud-bom/build.gradle
+++ b/oraclecloud-bom/build.gradle
@@ -5,6 +5,8 @@ plugins {
 
 dependencies {
     constraints {
+        api(libs.jackson2.databind)
+
         for (name in gradle.ociArtifacts) {
             api "com.oracle.oci.sdk:$name:$gradle.ociVersion"
         }

--- a/oraclecloud-bom/build.gradle
+++ b/oraclecloud-bom/build.gradle
@@ -6,7 +6,6 @@ plugins {
 dependencies {
     constraints {
         api(libs.jackson2.databind)
-
         for (name in gradle.ociArtifacts) {
             api "com.oracle.oci.sdk:$name:$gradle.ociVersion"
         }

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GHSA-5jmj-h7xm-6q6v"
+reason = "Cannot be fixed by staying on Jackson 2; OSV says the fix is Jackson 3.1.4"


### PR DESCRIPTION
Add Jackson Databind constraints to the Oracle Cloud Gradle convention plugins and BOM so OCI SDK metadata, base modules, and consumers resolve a consistent managed version across implementation, compile-only, runtime, and test configurations.

This ensure Jackson version 2.21.4, a version containing multiple security patches, is used.