### PR TITLE
make metrics more configurable

### DIFF
--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -19,7 +19,9 @@ import com.oracle.bmc.monitoring.model.MetricDataDetails;
 import com.oracle.bmc.monitoring.model.PostMetricDataDetails;
 import com.oracle.bmc.monitoring.requests.PostMetricDataRequest;
 import com.oracle.bmc.monitoring.responses.PostMetricDataResponse;
+import com.oracle.bmc.retrier.RetryConfiguration;
 import com.oracle.bmc.util.internal.StringUtils;
+import com.oracle.bmc.waiter.MaxAttemptsTerminationStrategy;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
@@ -112,6 +114,9 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
 
                 PostMetricDataResponse postMetricDataResponse = monitoringIngestionClient.postMetricData(PostMetricDataRequest.builder()
                     .postMetricDataDetails(builder.build())
+                    .retryConfiguration(RetryConfiguration.builder()
+                        .terminationStrategy(new MaxAttemptsTerminationStrategy(oracleCloudConfig.retryAttempts() + 1))
+                        .build())
                     .build());
 
                 if (logger.isDebugEnabled() && !postMetricDataResponse.getPostMetricDataResponseDetails().getFailedMetrics().isEmpty()) {

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/AbstractOracleCloudMeterRegistry.java
@@ -47,12 +47,16 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
     private final Logger logger = LoggerFactory.getLogger(AbstractOracleCloudMeterRegistry.class);
     private final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(OracleCloudMetricsNamingConvention.class);
     private final Provider<MonitoringIngestionClient> monitoringIngestionClientProvider;
+    private final RetryConfiguration retryConfiguration;
     private MonitoringIngestionClient monitoringIngestionClient;
 
     protected AbstractOracleCloudMeterRegistry(OracleCloudConfig oracleCloudConfig, Clock clock, Provider<MonitoringIngestionClient> monitoringIngestionClientProvider, ThreadFactory threadFactory) {
         super(oracleCloudConfig, clock);
         this.monitoringIngestionClientProvider = monitoringIngestionClientProvider;
         this.oracleCloudConfig = oracleCloudConfig;
+        this.retryConfiguration = RetryConfiguration.builder()
+            .terminationStrategy(new MaxAttemptsTerminationStrategy(oracleCloudConfig.retryAttempts() + 1))
+            .build();
         config().namingConvention(new OracleCloudMetricsNamingConvention());
         config().commonTags("application", this.oracleCloudConfig.applicationName());
         start(threadFactory);
@@ -114,9 +118,7 @@ abstract class AbstractOracleCloudMeterRegistry extends StepMeterRegistry {
 
                 PostMetricDataResponse postMetricDataResponse = monitoringIngestionClient.postMetricData(PostMetricDataRequest.builder()
                     .postMetricDataDetails(builder.build())
-                    .retryConfiguration(RetryConfiguration.builder()
-                        .terminationStrategy(new MaxAttemptsTerminationStrategy(oracleCloudConfig.retryAttempts() + 1))
-                        .build())
+                    .retryConfiguration(retryConfiguration)
                     .build());
 
                 if (logger.isDebugEnabled() && !postMetricDataResponse.getPostMetricDataResponseDetails().getFailedMetrics().isEmpty()) {

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudConfig.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudConfig.java
@@ -101,6 +101,20 @@ public interface OracleCloudConfig extends StepRegistryConfig {
         return getInteger(this, "batchSize").orElse(50);
     }
 
+    /**
+     * @return number of retries for a failed metrics request, defaults to 1.
+     */
+    default int retryAttempts() {
+        return getInteger(this, "retryAttempts").orElse(1);
+    }
+
+    /**
+     * @return maximum raw datapoints retained per meter before the next publish, defaults to 1000.
+     */
+    default int maxBufferedDatapoints() {
+        return getInteger(this, "maxBufferedDatapoints").orElse(1000);
+    }
+
     @Override
     default Validated<?> validate() {
         return MeterRegistryConfigValidator.checkAll(this,
@@ -112,6 +126,12 @@ public interface OracleCloudConfig extends StepRegistryConfig {
                                 InvalidReason.MALFORMED);
                     }
                     return Validated.valid(prefix() + ".namespace", namespace());
-                });
+                },
+                c -> retryAttempts() < 0
+                    ? Validated.invalid(prefix() + ".retryAttempts", retryAttempts(), "must be greater than or equal to 0", InvalidReason.MALFORMED)
+                    : Validated.valid(prefix() + ".retryAttempts", retryAttempts()),
+                c -> maxBufferedDatapoints() < 1
+                    ? Validated.invalid(prefix() + ".maxBufferedDatapoints", maxBufferedDatapoints(), "must be greater than 0", InvalidReason.MALFORMED)
+                    : Validated.valid(prefix() + ".maxBufferedDatapoints", maxBufferedDatapoints()));
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudRawMeterRegistry.java
@@ -79,7 +79,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
     public Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
                           PauseDetector pauseDetector) {
         Timer timer = new OracleCloudTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-            this.oracleCloudConfig.step().toMillis(), false);
+            this.oracleCloudConfig.step().toMillis(), false, oracleCloudConfig.maxBufferedDatapoints());
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -90,7 +90,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
      */
     @Override
     public Counter newCounter(Meter.Id id) {
-        return new OracleCloudCounter(id, clock, oracleCloudConfig.step().toMillis());
+        return new OracleCloudCounter(id, clock, oracleCloudConfig.step().toMillis(), oracleCloudConfig.maxBufferedDatapoints());
     }
 
     /**
@@ -104,7 +104,7 @@ public class OracleCloudRawMeterRegistry extends AbstractOracleCloudMeterRegistr
     public DistributionSummary newDistributionSummary(Meter.Id id,
                                                          DistributionStatisticConfig distributionStatisticConfig, double scale) {
         DistributionSummary summary = new OracleCloudDistributionSummary(id, clock, distributionStatisticConfig, scale,
-            oracleCloudConfig.step().toMillis(), false);
+            oracleCloudConfig.step().toMillis(), false, oracleCloudConfig.maxBufferedDatapoints());
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
     }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
@@ -27,7 +27,11 @@ import java.util.concurrent.LinkedBlockingQueue;
  * DataPointProvider stores the {@link Datapoint}.
  */
 final class DataPointProvider {
-    private final BlockingQueue<Datapoint> datapoints = new LinkedBlockingQueue<>();
+    private final BlockingQueue<Datapoint> datapoints;
+
+    DataPointProvider(int maxBufferedDatapoints) {
+        datapoints = new LinkedBlockingQueue<>(maxBufferedDatapoints);
+    }
 
     /**
      * Produces the list of datapoints that will be sent. It will also perform cleanup
@@ -46,7 +50,7 @@ final class DataPointProvider {
      * @param value of the datapoint
      */
     void createDataPoint(Double value) {
-        datapoints.add(Datapoint.builder().timestamp(new Date()).value(value).build());
+        datapoints.offer(Datapoint.builder().timestamp(new Date()).value(value).build());
     }
 
     /**
@@ -55,6 +59,6 @@ final class DataPointProvider {
      * @param count of the datapoint
      */
     void createDataPoint(Double value, Integer count) {
-        datapoints.add(Datapoint.builder().timestamp(new Date()).value(value).count(count).build());
+        datapoints.offer(Datapoint.builder().timestamp(new Date()).value(value).count(count).build());
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
@@ -73,7 +73,7 @@ final class DataPointProvider {
     private synchronized void add(Datapoint datapoint) {
         if (!datapoints.offer(datapoint)) {
             datapoints.poll();
-            datapoints.offer(datapoint);
+            datapoints.add(datapoint);
         }
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/DataPointProvider.java
@@ -27,9 +27,17 @@ import java.util.concurrent.LinkedBlockingQueue;
  * DataPointProvider stores the {@link Datapoint}.
  */
 final class DataPointProvider {
+    static final int DEFAULT_MAX_BUFFERED_DATAPOINTS = 1000;
     private final BlockingQueue<Datapoint> datapoints;
 
+    DataPointProvider() {
+        this(DEFAULT_MAX_BUFFERED_DATAPOINTS);
+    }
+
     DataPointProvider(int maxBufferedDatapoints) {
+        if (maxBufferedDatapoints < 1) {
+            throw new IllegalArgumentException("maxBufferedDatapoints must be greater than 0");
+        }
         datapoints = new LinkedBlockingQueue<>(maxBufferedDatapoints);
     }
 
@@ -39,7 +47,7 @@ final class DataPointProvider {
      *
      * @return list of {@link Datapoint}
      */
-    List<Datapoint> produceDatapoints() {
+    synchronized List<Datapoint> produceDatapoints() {
         List<Datapoint> datapointsToReturn = new ArrayList<>();
         datapoints.drainTo(datapointsToReturn);
         return datapointsToReturn;
@@ -50,7 +58,7 @@ final class DataPointProvider {
      * @param value of the datapoint
      */
     void createDataPoint(Double value) {
-        datapoints.offer(Datapoint.builder().timestamp(new Date()).value(value).build());
+        add(Datapoint.builder().timestamp(new Date()).value(value).build());
     }
 
     /**
@@ -59,6 +67,13 @@ final class DataPointProvider {
      * @param count of the datapoint
      */
     void createDataPoint(Double value, Integer count) {
-        datapoints.offer(Datapoint.builder().timestamp(new Date()).value(value).count(count).build());
+        add(Datapoint.builder().timestamp(new Date()).value(value).count(count).build());
+    }
+
+    private synchronized void add(Datapoint datapoint) {
+        if (!datapoints.offer(datapoint)) {
+            datapoints.poll();
+            datapoints.offer(datapoint);
+        }
     }
 }

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
@@ -29,6 +29,10 @@ import java.util.List;
 public final class OracleCloudCounter extends StepCounter implements OracleCloudDatapointProducer {
     private final DataPointProvider dataPointProvider;
 
+    public OracleCloudCounter(Id id, Clock clock, long stepMillis) {
+        this(id, clock, stepMillis, DataPointProvider.DEFAULT_MAX_BUFFERED_DATAPOINTS);
+    }
+
     public OracleCloudCounter(Id id, Clock clock, long stepMillis, int maxBufferedDatapoints) {
         super(id, clock, stepMillis);
         dataPointProvider = new DataPointProvider(maxBufferedDatapoints);

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudCounter.java
@@ -27,10 +27,11 @@ import java.util.List;
  */
 @Internal
 public final class OracleCloudCounter extends StepCounter implements OracleCloudDatapointProducer {
-    private final DataPointProvider dataPointProvider = new DataPointProvider();
+    private final DataPointProvider dataPointProvider;
 
-    public OracleCloudCounter(Id id, Clock clock, long stepMillis) {
+    public OracleCloudCounter(Id id, Clock clock, long stepMillis, int maxBufferedDatapoints) {
         super(id, clock, stepMillis);
+        dataPointProvider = new DataPointProvider(maxBufferedDatapoints);
     }
 
     @Override

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
@@ -29,6 +29,10 @@ public class OracleCloudDistributionSummary extends StepDistributionSummary impl
 
     private final DataPointProvider dataPointProvider;
 
+    public OracleCloudDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles) {
+        this(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles, DataPointProvider.DEFAULT_MAX_BUFFERED_DATAPOINTS);
+    }
+
     public OracleCloudDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles, int maxBufferedDatapoints) {
         super(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles);
         dataPointProvider = new DataPointProvider(maxBufferedDatapoints);

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudDistributionSummary.java
@@ -27,10 +27,11 @@ import java.util.List;
  */
 public class OracleCloudDistributionSummary extends StepDistributionSummary implements OracleCloudDatapointProducer {
 
-    private final DataPointProvider dataPointProvider = new DataPointProvider();
+    private final DataPointProvider dataPointProvider;
 
-    public OracleCloudDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles) {
+    public OracleCloudDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles, int maxBufferedDatapoints) {
         super(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles);
+        dataPointProvider = new DataPointProvider(maxBufferedDatapoints);
     }
 
     @Override

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
@@ -30,11 +30,12 @@ import java.util.concurrent.TimeUnit;
  */
 public class OracleCloudTimer extends StepTimer implements OracleCloudDatapointProducer {
     private final TimeUnit timeUnit;
-    private final DataPointProvider dataPointProvider = new DataPointProvider();
+    private final DataPointProvider dataPointProvider;
 
-    public OracleCloudTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles) {
+    public OracleCloudTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles, int maxBufferedDatapoints) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, supportsAggregablePercentiles);
         this.timeUnit = baseTimeUnit;
+        dataPointProvider = new DataPointProvider(maxBufferedDatapoints);
     }
 
     @Override

--- a/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
+++ b/oraclecloud-micrometer/src/main/java/io/micronaut/oraclecloud/monitoring/primitives/OracleCloudTimer.java
@@ -32,6 +32,10 @@ public class OracleCloudTimer extends StepTimer implements OracleCloudDatapointP
     private final TimeUnit timeUnit;
     private final DataPointProvider dataPointProvider;
 
+    public OracleCloudTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles) {
+        this(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, supportsAggregablePercentiles, DataPointProvider.DEFAULT_MAX_BUFFERED_DATAPOINTS);
+    }
+
     public OracleCloudTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles, int maxBufferedDatapoints) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, supportsAggregablePercentiles);
         this.timeUnit = baseTimeUnit;

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
@@ -133,6 +133,43 @@ class OracleCloudMeterRawRegistrySpec extends Specification {
         data.datapoints[1].value == 1
     }
 
+    def "test raw datapoints are bounded"() {
+        given:
+        def counter = cloudMeterRegistry.counter("bounded-counter")
+
+        when:
+        (oracleCloudConfig.maxBufferedDatapoints() + 1).times { counter.increment() }
+        def data = cloudMeterRegistry.trackRawData(counter).findFirst().get()
+
+        then:
+        data.datapoints.size() == oracleCloudConfig.maxBufferedDatapoints()
+    }
+
+    def "test failed post discards raw datapoints after one retry"() {
+        given:
+        def client = Mock(MonitoringIngestionClient) {
+            postMetricData(_) >> { throw new RuntimeException("unavailable") }
+        }
+        def registry = new OracleCloudRawMeterRegistry(oracleCloudConfig, mockClock, new Provider<MonitoringIngestionClient>() {
+            @Override
+            MonitoringIngestionClient get() {
+                client
+            }
+        })
+        def counter = registry.counter("discarded-counter")
+        counter.increment()
+
+        when:
+        registry.publish()
+
+        then:
+        1 * client.postMetricData({ it.retryConfiguration.terminationStrategy.maxAttempts == 2 })
+        registry.trackRawData(counter).findFirst().empty
+
+        cleanup:
+        registry.close()
+    }
+
     def "test it can track timer"() {
         given:
         def timer = cloudMeterRegistry.timer("timer")

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
@@ -2,13 +2,19 @@ package io.micronaut.oraclecloud.monitoring.micrometer
 
 import com.oracle.bmc.monitoring.model.Datapoint
 import io.micrometer.core.instrument.*
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
+import io.micrometer.core.instrument.distribution.pause.NoPauseDetector
 import io.micronaut.oraclecloud.monitoring.MonitoringIngestionClient
+import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudCounter
+import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudDistributionSummary
+import io.micronaut.oraclecloud.monitoring.primitives.OracleCloudTimer
 import jakarta.inject.Provider
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
 class OracleCloudMeterRawRegistrySpec extends Specification {
@@ -145,6 +151,25 @@ class OracleCloudMeterRawRegistrySpec extends Specification {
         data.datapoints.size() == oracleCloudConfig.maxBufferedDatapoints()
         data.datapoints.first().value == 2
         data.datapoints.last().value == oracleCloudConfig.maxBufferedDatapoints() + 1
+    }
+
+    def "test legacy primitive constructors use the default buffer size"() {
+        when:
+        new OracleCloudCounter(new Meter.Id("counter", Tags.empty(), null, null, Meter.Type.COUNTER), mockClock, oracleCloudConfig.step().toMillis())
+        new OracleCloudDistributionSummary(new Meter.Id("summary", Tags.empty(), null, null, Meter.Type.DISTRIBUTION_SUMMARY), mockClock, DistributionStatisticConfig.DEFAULT, 1, oracleCloudConfig.step().toMillis(), false)
+        new OracleCloudTimer(new Meter.Id("timer", Tags.empty(), null, null, Meter.Type.TIMER), mockClock, DistributionStatisticConfig.DEFAULT, new NoPauseDetector(), TimeUnit.MILLISECONDS, oracleCloudConfig.step().toMillis(), false)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "test primitive buffer size must be positive"() {
+        when:
+        new OracleCloudCounter(new Meter.Id("counter", Tags.empty(), null, null, Meter.Type.COUNTER), mockClock, oracleCloudConfig.step().toMillis(), 0)
+
+        then:
+        def exception = thrown(IllegalArgumentException)
+        exception.message == "maxBufferedDatapoints must be greater than 0"
     }
 
     def "test failed post discards raw datapoints and configures retries"() {

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/micrometer/OracleCloudMeterRawRegistrySpec.groovy
@@ -133,19 +133,21 @@ class OracleCloudMeterRawRegistrySpec extends Specification {
         data.datapoints[1].value == 1
     }
 
-    def "test raw datapoints are bounded"() {
+    def "test raw datapoints discard the oldest when bounded"() {
         given:
         def counter = cloudMeterRegistry.counter("bounded-counter")
 
         when:
-        (oracleCloudConfig.maxBufferedDatapoints() + 1).times { counter.increment() }
+        (1..oracleCloudConfig.maxBufferedDatapoints() + 1).each { counter.increment(it) }
         def data = cloudMeterRegistry.trackRawData(counter).findFirst().get()
 
         then:
         data.datapoints.size() == oracleCloudConfig.maxBufferedDatapoints()
+        data.datapoints.first().value == 2
+        data.datapoints.last().value == oracleCloudConfig.maxBufferedDatapoints() + 1
     }
 
-    def "test failed post discards raw datapoints after one retry"() {
+    def "test failed post discards raw datapoints and configures retries"() {
         given:
         def client = Mock(MonitoringIngestionClient) {
             postMetricData(_) >> { throw new RuntimeException("unavailable") }
@@ -164,7 +166,7 @@ class OracleCloudMeterRawRegistrySpec extends Specification {
 
         then:
         1 * client.postMetricData({ it.retryConfiguration.terminationStrategy.maxAttempts == 2 })
-        registry.trackRawData(counter).findFirst().empty
+        registry.getMetricData().empty
 
         cleanup:
         registry.close()

--- a/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/primitives/DataPointProviderSpec.groovy
+++ b/oraclecloud-micrometer/src/test/groovy/io/micronaut/oraclecloud/monitoring/primitives/DataPointProviderSpec.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.oraclecloud.monitoring.primitives
+
+import spock.lang.Specification
+
+class DataPointProviderSpec extends Specification {
+
+    def "uses the default buffer size"() {
+        expect:
+        new DataPointProvider().produceDatapoints().empty
+    }
+}


### PR DESCRIPTION
  - Cap raw datapoints at 1,000 per meter by default; overflow is discarded.
  - Retry failed metric posts once by default, then discard the batch.
  - Add retry-attempts and max-buffered-datapoints configuration properties with validation.
  - Add coverage for bounded queues and failed delivery behavior.