### PR TITLE
Fix OCI Netty InputStream retries

### DIFF
--- a/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
+++ b/oraclecloud-httpclient-apache-http-core/src/test/java/io/micronaut/oraclecloud/httpclient/apache/core/ApacheNettyTest.java
@@ -118,6 +118,12 @@ public class ApacheNettyTest extends NettyTest {
         super.functionsClientTest();
     }
 
+    @Override
+    @Disabled // not implemented
+    public void functionsClientRetriesInputStreamBodyUsesResetStream() throws CertificateException {
+        super.functionsClientRetriesInputStreamBodyUsesResetStream();
+    }
+
     @Test
     public void location() throws Exception {
         netty.handleOneRequest((ctx, request) -> {

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/MicronautHttpRequest.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/httpclient/netty/MicronautHttpRequest.java
@@ -79,6 +79,7 @@ final class MicronautHttpRequest implements HttpRequest {
 
     private boolean expectContinue;
     private Object returningBody;
+    private long inputStreamContentLength = UNKNOWN_CONTENT_LENGTH;
     @Nullable
     private CloseableByteBody byteBody;
 
@@ -120,8 +121,16 @@ final class MicronautHttpRequest implements HttpRequest {
         this.blockHint = from.blockHint;
         this.expectContinue = from.expectContinue;
 
-        this.returningBody = from.returningBody;
-        this.byteBody = from.byteBody == null ? null : from.byteBody.split(ByteBody.SplitBackpressureMode.FASTEST); // todo
+        if (from.byteBody == null) {
+            this.returningBody = from.returningBody;
+            this.inputStreamContentLength = from.inputStreamContentLength;
+            this.byteBody = null;
+        } else if (from.returningBody instanceof InputStream inputStream) {
+            body(inputStream, from.inputStreamContentLength);
+        } else {
+            this.returningBody = from.returningBody;
+            this.byteBody = from.byteBody.split(ByteBody.SplitBackpressureMode.FASTEST); // todo
+        }
     }
 
     private static MutableHttpRequest<?> copyRequest(io.micronaut.http.HttpRequest<?> original) {
@@ -156,11 +165,13 @@ final class MicronautHttpRequest implements HttpRequest {
         if (body instanceof String s) {
             byteBody = AvailableByteArrayBody.create(READ_BUFFER_FACTORY.copyOf(s, StandardCharsets.UTF_8));
             returningBody = body;
+            inputStreamContentLength = UNKNOWN_CONTENT_LENGTH;
         } else if (body instanceof InputStream) {
             body((InputStream) body, UNKNOWN_CONTENT_LENGTH);
         } else if (body == null) {
             byteBody = AvailableByteArrayBody.create(READ_BUFFER_FACTORY.createEmpty());
             returningBody = "";
+            inputStreamContentLength = UNKNOWN_CONTENT_LENGTH;
         } else {
             // todo: would be better to write directly to ByteBuf here, but RequestSignerImpl does not yet support
             //  anything but String
@@ -172,6 +183,7 @@ final class MicronautHttpRequest implements HttpRequest {
             }
             byteBody = AvailableByteArrayBody.create(READ_BUFFER_FACTORY.copyOf(json, StandardCharsets.UTF_8));
             returningBody = json;
+            inputStreamContentLength = UNKNOWN_CONTENT_LENGTH;
         }
         return this;
     }
@@ -185,6 +197,7 @@ final class MicronautHttpRequest implements HttpRequest {
             ByteBodyFactory.createDefault(ByteArrayBufferFactory.INSTANCE)
         );
         returningBody = body;
+        inputStreamContentLength = contentLength;
         return this;
     }
 

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/LegacyNettyManagedTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/httpclient/netty/LegacyNettyManagedTest.java
@@ -34,4 +34,11 @@ public class LegacyNettyManagedTest extends NettyManagedTest {
     public void functionsClientTest() throws CertificateException {
         super.functionsClientTest();
     }
+
+    @Override
+    @Disabled("Legacy client does not pass the generated Functions invocation test setup")
+    public void functionsClientRetriesInputStreamBodyUsesResetStream() throws CertificateException {
+        super.functionsClientRetriesInputStreamBodyUsesResetStream();
+    }
+
 }

--- a/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
+++ b/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
@@ -24,9 +24,12 @@ import com.oracle.bmc.monitoring.MonitoringClient;
 import com.oracle.bmc.monitoring.model.CreateAlarmDetails;
 import com.oracle.bmc.monitoring.requests.CreateAlarmRequest;
 import com.oracle.bmc.monitoring.requests.DeleteAlarmRequest;
+import com.oracle.bmc.retrier.RetryConfiguration;
 import com.oracle.bmc.streaming.model.PutMessagesDetails;
 import com.oracle.bmc.streaming.model.PutMessagesDetailsEntry;
 import com.oracle.bmc.streaming.model.PutMessagesResult;
+import com.oracle.bmc.waiter.FixedTimeDelayStrategy;
+import com.oracle.bmc.waiter.MaxAttemptsTerminationStrategy;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
 import io.micronaut.serde.annotation.SerdeImport;
@@ -97,6 +100,45 @@ public abstract class NettyTest {
 
     protected final Channel getServerChannel() {
         return netty.serverChannel;
+    }
+
+    @Test
+    public void copiedInputStreamBodyUsesResetStream() throws Exception {
+        List<String> receivedBodies = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            netty.handleOneRequest((ctx, request) -> {
+                Assertions.assertEquals(HttpMethod.POST, request.method());
+                Assertions.assertEquals("/foo", request.uri());
+                receivedBodies.add(((FullHttpRequest) request).content().toString(StandardCharsets.UTF_8));
+
+                DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+                computeContentLength(response);
+                ctx.writeAndFlush(response);
+            });
+        }
+
+        try (HttpClient client = newBuilder().build()) {
+            ByteArrayInputStream body = new ByteArrayInputStream("abcdef".getBytes(StandardCharsets.UTF_8));
+            HttpRequest request = client.createRequest(Method.POST)
+                .appendPathPart("foo")
+                .body(body);
+
+            try {
+                for (int i = 0; i < 3; i++) {
+                    if (i > 0) {
+                        body.reset();
+                    }
+                    HttpRequest requestAttempt = request.copy();
+                    try (HttpResponse response = requestAttempt.execute().toCompletableFuture().get()) {
+                        Assertions.assertEquals(200, response.status());
+                    }
+                }
+            } finally {
+                request.discard();
+            }
+        }
+
+        Assertions.assertEquals(List.of("abcdef", "abcdef", "abcdef"), receivedBodies);
     }
 
     @Test
@@ -700,6 +742,65 @@ public abstract class NettyTest {
                 .fnIntent(InvokeFunctionRequest.FnIntent.Httprequest)
                 .fnInvokeType(InvokeFunctionRequest.FnInvokeType.Sync)
                 .invokeFunctionBody(new KeepOpenInputStream(new ByteArrayInputStream(body)))
+                .build());
+        }
+    }
+
+    @Test
+    public void functionsClientRetriesInputStreamBodyUsesResetStream() throws CertificateException {
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        byte[] body = new byte[10];
+        ThreadLocalRandom.current().nextBytes(body);
+
+        for (int i = 0; i < 3; i++) {
+            int attempt = i;
+            netty.handleOneRequest((ctx, request) -> {
+                Assertions.assertEquals(HttpMethod.POST, request.method());
+                Assertions.assertEquals("/20181201/functions/function-id/actions/invoke", request.uri());
+                Assertions.assertTrue(request.headers().get(HttpHeaderNames.AUTHORIZATION).contains("content-length"));
+
+                SignatureV1.verify((FullHttpRequest) request, ssc.cert().getPublicKey());
+
+                Assertions.assertArrayEquals(body, ByteBufUtil.getBytes(((FullHttpRequest) request).content()));
+
+                HttpResponseStatus status = attempt < 2 ? HttpResponseStatus.INTERNAL_SERVER_ERROR : HttpResponseStatus.OK;
+                DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+                    HttpVersion.HTTP_1_1, status,
+                    Unpooled.copiedBuffer("{}", StandardCharsets.UTF_8)
+                );
+                response.headers().add("Content-Type", "application/json");
+                computeContentLength(response);
+                ctx.writeAndFlush(response);
+            });
+        }
+
+        FunctionsInvokeClient.Builder builder = FunctionsInvokeClient.builder();
+        customize(builder);
+        try (FunctionsInvokeClient invokeClient = builder
+            .build(SimpleAuthenticationDetailsProvider.builder()
+                .tenantId("tenantId")
+                .userId("userId")
+                .fingerprint("fingerprint")
+                .passPhrase("")
+                .region(Region.US_PHOENIX_1)
+                .privateKeySupplier(() -> {
+                    try {
+                        return new FileInputStream(ssc.privateKey());
+                    } catch (FileNotFoundException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
+                .build())) {
+
+            invokeClient.invokeFunction(InvokeFunctionRequest.builder()
+                .functionId("function-id")
+                .fnIntent(InvokeFunctionRequest.FnIntent.Httprequest)
+                .fnInvokeType(InvokeFunctionRequest.FnInvokeType.Sync)
+                .invokeFunctionBody(new ByteArrayInputStream(body))
+                .retryConfiguration(RetryConfiguration.builder()
+                    .terminationStrategy(new MaxAttemptsTerminationStrategy(3))
+                    .delayStrategy(new FixedTimeDelayStrategy(0))
+                    .build())
                 .build());
         }
     }

--- a/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
+++ b/test-suite-http-client/src/main/java/io/micronaut/oraclecloud/httpclient/NettyTest.java
@@ -121,6 +121,7 @@ public abstract class NettyTest {
             ByteArrayInputStream body = new ByteArrayInputStream("abcdef".getBytes(StandardCharsets.UTF_8));
             HttpRequest request = client.createRequest(Method.POST)
                 .appendPathPart("foo")
+                .header("content-type", "text/plain")
                 .body(body);
 
             try {


### PR DESCRIPTION
## Summary
- backport #1353 to 5.6.x
- rebuild copied Micronaut OCI Netty InputStream request bodies from the reset stream instead of re-splitting the streaming ByteBody
- add shared Netty client regression coverage for copied InputStream requests and generated Functions client retries
- skip the generated Functions retry regression for providers where that Functions setup is unsupported

## Validation
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java21 ./gradlew :micronaut-oraclecloud-httpclient-netty:test --tests 'io.micronaut.oraclecloud.httpclient.netty.NettyUnmanagedTest.functionsClientRetriesInputStreamBodyUsesResetStream' --tests 'io.micronaut.oraclecloud.httpclient.netty.LegacyNettyManagedTest.copiedInputStreamBodyUsesResetStream' -q`
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java21 ./gradlew :micronaut-oraclecloud-httpclient-netty:test -q`
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java21 ./gradlew :micronaut-oraclecloud-httpclient-netty:check -q`
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java21 ./gradlew :micronaut-oraclecloud-httpclient-apache-http-core:test --tests '*copiedInputStreamBodyUsesResetStream' -q`

Note: full `:micronaut-oraclecloud-httpclient-apache-http-core:check` was attempted locally but existing `fullSetupTestManagedCustomProperties()` tests require OCI auth config (`/home/opc/.oci/config`) in this environment; the new copied InputStream regression passed for Apache.