### PR TITLE
Fix OKE workload identity Serde metadata

### DIFF
--- a/oraclecloud-httpclient-netty/build.gradle
+++ b/oraclecloud-httpclient-netty/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testRuntimeOnly mn.micronaut.runtime
 
     testImplementation mn.micronaut.inject.java.test
+    testImplementation libs.oci.oke.workload.identity
     testImplementation mnSerde.micronaut.serde.processor
     testImplementation projects.micronautOraclecloudSerdeProcessor
     testImplementation projects.micronautOraclecloudSerdeInternalProcessor

--- a/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
+++ b/oraclecloud-httpclient-netty/src/main/java/io/micronaut/oraclecloud/serde/OciSdkMicronautSerializer.java
@@ -20,6 +20,8 @@ import com.oracle.bmc.auth.internal.JWK;
 import com.oracle.bmc.auth.internal.X509FederationClient;
 import com.oracle.bmc.auth.okeworkloadidentity.internal.GetOkeResourcePrincipalSessionTokenDetails;
 import com.oracle.bmc.auth.okeworkloadidentity.internal.OkeResourcePrincipalSessionToken;
+import com.oracle.bmc.auth.okeworkloadidentity.internal.contract.GetOkeResourcePrincipalSessionTokenAndKeysDetails;
+import com.oracle.bmc.auth.okeworkloadidentity.internal.contract.OkeResourcePrincipalSessionTokenAndKeys;
 import com.oracle.bmc.encryption.internal.EncryptionHeader;
 import com.oracle.bmc.encryption.internal.EncryptionKey;
 import com.oracle.bmc.http.client.Serializer;
@@ -49,6 +51,8 @@ import java.util.Map;
 @SerdeImport(X509FederationClient.X509FederationRequest.class)
 @SerdeImport(GetOkeResourcePrincipalSessionTokenDetails.class)
 @SerdeImport(OkeResourcePrincipalSessionToken.class)
+@SerdeImport(GetOkeResourcePrincipalSessionTokenAndKeysDetails.class)
+@SerdeImport(OkeResourcePrincipalSessionTokenAndKeys.class)
 @SerdeImport(value = EncryptionHeader.class, deserializable = false)
 @SerdeImport(EncryptionKey.class)
 public final class OciSdkMicronautSerializer implements Serializer {

--- a/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/serde/OkeWorkloadIdentitySerdeTest.java
+++ b/oraclecloud-httpclient-netty/src/test/java/io/micronaut/oraclecloud/serde/OkeWorkloadIdentitySerdeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.oraclecloud.serde;
+
+import com.oracle.bmc.auth.okeworkloadidentity.internal.contract.GetOkeResourcePrincipalSessionTokenAndKeysDetails;
+import com.oracle.bmc.auth.okeworkloadidentity.internal.contract.OkeResourcePrincipalSessionTokenAndKeys;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OkeWorkloadIdentitySerdeTest {
+
+    @Test
+    void serializesAndDeserializesOkeWorkloadIdentityTokenExchangeModels() throws Exception {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            JsonMapper jsonMapper = context.getBean(JsonMapper.class);
+
+            jsonMapper.writeValueAsString(GetOkeResourcePrincipalSessionTokenAndKeysDetails.builder().build());
+            OkeResourcePrincipalSessionTokenAndKeys token = jsonMapper.readValue(
+                "{\"token\":\"token\",\"privateKey\":\"private\",\"publicKey\":\"public\"}",
+                OkeResourcePrincipalSessionTokenAndKeys.class
+            );
+
+            assertEquals("token", token.getToken());
+        }
+    }
+}


### PR DESCRIPTION
 OCI SDK 3.91.0 uses cached OKE workload-identity token exchange models that were not registered for Micronaut Serde:

  - `GetOkeResourcePrincipalSessionTokenAndKeysDetails`
  - `OkeResourcePrincipalSessionTokenAndKeys`

  This caused OKE deployments to fail with `No bean introspection available` while obtaining or refreshing the workload identity token.

  Add the missing `@SerdeImport` declarations to the Netty OCI serializer and a regression test covering serialization and deserialization through `JsonMapper`.

  ### Verification

  ```bash
  ./gradlew --no-daemon \
    :micronaut-oraclecloud-httpclient-netty:test \
    --tests io.micronaut.oraclecloud.serde.OkeWorkloadIdentitySerdeTest \
    --rerun-tasks
```
Closes : #1362
