### PR TITLE
Fix the kubernetes client and Fn function TCK test failures on 6.2.x

### DIFF
--- a/oraclecloud-oke-kubernetes-client/src/test/groovy/io/micronaut/oraclecloud/oke/kubernetes/client/MockKubernetesSpec.groovy
+++ b/oraclecloud-oke-kubernetes-client/src/test/groovy/io/micronaut/oraclecloud/oke/kubernetes/client/MockKubernetesSpec.groovy
@@ -56,7 +56,7 @@ class MockKubernetesSpec extends Specification {
         V1NamespaceList list = coreV1Api.listNamespace(
                 null, null, null, null,
                 null, null, null, null,
-                null, null, null
+                null, null, null, null
         )
 
         then:

--- a/test-suite-http-server-tck-oraclecloud-function-http/src/test/java/io/micronaut/http/server/tck/oraclecloud/function/OracleCloudFunctionServerUnderTest.java
+++ b/test-suite-http-server-tck-oraclecloud-function-http/src/test/java/io/micronaut/http/server/tck/oraclecloud/function/OracleCloudFunctionServerUnderTest.java
@@ -59,7 +59,7 @@ public class OracleCloudFunctionServerUnderTest implements ServerUnderTest {
         properties.put("micronaut.server.context-path", "/");
         properties.putIfAbsent("micronaut.propagation", "thread-local");
         properties.put("endpoints.health.service-ready-indicator-enabled", StringUtils.FALSE);
-        properties.put("endpoints.refresh.enabled", StringUtils.FALSE);
+        properties.putIfAbsent("endpoints.refresh.enabled", StringUtils.FALSE);
         properties.putAll(properties.entrySet().stream().collect(Collectors.toMap(
                 // Set the configured properties for the fn fork
                 e -> "fn.test.config." + e.getKey(), Entry::getValue


### PR DESCRIPTION
Fixes the three pre-existing test failures that turn `build (25)` / `Java CI / Test Report (25)` red on every PR against `6.2.x`. They appear on #1370 (only workflows and the Gradle wrapper), on #1375 (only micronaut-micrometer 6.0.1 -> 6.0.2) and on the 6.2.x head push (88f2614e6). They also fail with the catalog's core 5.1.11, so core 5.2 does not cause them. Part of the core 5.2 rollout, micronaut-projects/micronaut-core#13110.

### `MockKubernetesSpec` "test kubernetes request"
`MissingMethodException: No signature of method: listNamespace ... (null × 11)`. In micronaut-kubernetes 9.0.0 (the catalog version), `CoreV1Api.listNamespace` takes 12 parameters, so the spec now passes 12 `null`s.

### `SimpleRequestWithCorsNotEnabledTest` (2 tests, 404)
The TCK test posts to `/refresh` with `endpoints.refresh.enabled=true`. `OracleCloudFunctionServerUnderTest` overwrote that with `false`, so the Fn harness answered 404. That override was added so the endpoint would not clash with the TCK's own `@Post("/refresh")` controller, which the core TCK no longer has. It is now `putIfAbsent`, so a test's own configuration wins. This fixes the harness itself, and no test is excluded. micronaut-gcp and micronaut-azure had the same fix. `CorsSimpleRequestTest` was already excluded in this suite and stays excluded.

### Verification (local, JDK 25)
- Unchanged 6.2.x: `:micronaut-oraclecloud-oke-kubernetes-client:test` shows 1 failure, and `:test-suite-http-server-tck-oraclecloud-function-http:test` shows 2 failures in 165 tests. These are the same failures as CI.
- With this change, `check` on both modules passes: kubernetes client 2 tests, 0 failures (1 skipped, needs OCI config); TCK 165 tests, 0 failures (1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
