### PR TITLE
Register OperatingSystemMXBean.getProcessCpuTime() for native images

### DIFF
--- a/oraclecloud-micrometer/src/main/resources/META-INF/native-image/io.micronaut.oraclecloud/micronaut-oraclecloud-micrometer/reflect-config.json
+++ b/oraclecloud-micrometer/src/main/resources/META-INF/native-image/io.micronaut.oraclecloud/micronaut-oraclecloud-micrometer/reflect-config.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "com.sun.management.OperatingSystemMXBean",
+    "methods": [
+      {
+        "name": "getProcessCpuTime",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Fixes the `nativeTest` failure blocking the core 5.2 bump in #1371.

### The failure

`:test-suite-java:nativeTest` fails with one test failure, `example.MicrometerTest > testMicrometer()`:

```
MissingReflectionRegistrationError: Cannot reflectively invoke method
'public abstract long com.sun.management.OperatingSystemMXBean.getProcessCpuTime()'
```

### Cause

`micrometer-core` ships its own `META-INF/native-image/io.micrometer/micrometer-core/reflect-config.json`, which registers `getCpuLoad`, `getProcessCpuLoad` and `getSystemCpuLoad` on `com.sun.management.OperatingSystemMXBean` — but **not** `getProcessCpuTime`, in any version from 1.15 through 1.16. `ProcessorMetrics` has always resolved and invoked that method to back the `process.cpu.time` gauge, and no Micronaut artifact registers it either.

Until now the method was not resolvable in a native image, so micrometer's `detectMethod` returned `null` and the gauge was never created. With micronaut-core 5.2 the method becomes queryable, so `ProcessorMetrics` registers the gauge and the first measurement fails on the missing *invoke* registration.

I confirmed this by differential native builds where **only the micronaut-core version differs** (same `micrometer-core` 1.16.7, same `micronaut-micrometer` 6.0.2, same GraalVM CE 25.0.2+10.1, same build args), binding micrometer's `ProcessorMetrics` to a `SimpleMeterRegistry`:

| micronaut-core | `process.cpu.time` | `process.cpu.usage` |
| --- | --- | --- |
| 5.1.12 | not registered (method not resolvable) | ✅ |
| 5.2.1 | gauge registered, **invoke throws** | not reached |
| 5.2.1 + this PR | ✅ `COUNT=2.08643E8` | ✅ |

This is a pre-existing metadata gap in micrometer rather than a micronaut-core regression — core does not touch `com.sun.management.OperatingSystemMXBean` — so it is fixed here. It would affect any native Oracle Cloud application exporting micrometer metrics, not only the test suite, which is why the registration goes in `oraclecloud-micrometer`'s main resources rather than the test suite. Worth an upstream micrometer issue as well.

### The change

One method registered, rather than a broad registration, following how `oraclecloud-logging` and `oraclecloud-atp` register native metadata in this repo.

### Verification

`./gradlew :test-suite-java:test :test-suite-java:nativeTest` on the #1371 branch with this change applied, on GraalVM CE 25.0.2:

- before: `TmpProcessorMetricsTest > processCpuTimeCanBeMeasured() FAILED` with the exact CI error
- after: `SUCCESSFUL`, `process.cpu.time` measures, `process.cpu.usage` still present

`MicrometerTest` itself cannot run locally (it needs `monitoring.compartment.ocid` and OCI credentials), so I reproduced the same call path with a temporary test; that temporary test is not part of this PR. The remaining local native failures are all `DisabledBeanException: Invalid Oracle Cloud Configuration`, expected without credentials.

### Not addressed here

The `BindException: Address already in use` failures in `OracleCloudSdkMetricsFilterSpec` and `OracleCloudV2MetadataResolverSpec` are pre-existing runner flakes, not caused by the bump — the identical four failures appear in the **green** 6.2.x run [34680361483](https://github.com/micronaut-projects/micronaut-oracle-cloud/actions/runs/34680361483), where retries pass them.

Part of the core 5.2 rollout tracked in micronaut-projects/micronaut-core#13110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
